### PR TITLE
MIDI Multi-Mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,105 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-03-11
+
+### Added — Application
+
+- **MIDI Input Multi-Mapping** — MIDI input now supports multiple independent
+  mappings in a table-based interface. Each mapping has its own device,
+  channel, mode (straight key or paddle), note assignment, decoder source
+  (RX/TX), and reverse-paddles toggle. Add, edit, duplicate, reorder, or
+  remove mappings freely. The previous single-mapping MIDI input has been
+  replaced by a configurable mapping table with an edit modal for each row.
+  Default mappings: straight key on note C4 (60) and paddle on D4/E4
+  (62/64), both on channel 1 (omni).
+- **MIDI Input Name & Colour** — Each MIDI input mapping can now have an
+  optional **Name** (e.g. a callsign) and **Colour** (CSS colour string).
+  When a name is set, it triggers automatic line breaks in the fullscreen
+  conversation views — the name appears as a prefix (like Firebase RTDB
+  user names), and the text is rendered in the chosen colour instead of the
+  default RX/TX colour. This enables **multi-user conversations** where
+  several operators key into the same app instance via separate MIDI
+  devices, and each operator's text appears on its own colour-coded line
+  in the fullscreen decoder/encoder views.
+- **MIDI Output Multi-Mapping** — MIDI output now supports multiple
+  independent mappings in the same table + edit modal pattern as MIDI
+  input. Each mapping has its own device, channel, mode (straight key or
+  paddle), note assignment, and **per-mapping forward selector** (TX only,
+  RX only, or Both). Default mappings: straight key on G♯5 (80) and
+  paddle on A♯5/C6 (82/84), both on channel 1, forward TX.
+- **MIDI Output Paddle Mode for Local Keyers** — Keyboard, mouse, and
+  touch keyer inputs now correctly drive MIDI output paddle-mode mappings
+  via the character-based playback path. Previously, local keyer inputs
+  only fired straight-key MIDI output notes in real time; paddle-mode
+  mappings were skipped. The fix passes a `paddleOnly` flag through the
+  forwarding chain so that paddle mappings receive decoded characters
+  while straight-key mappings continue to fire in real time without
+  double-firing.
+- **MIDI Device Enumeration When Disabled** — Both MIDI Input and MIDI
+  Output cards now enumerate available MIDI devices for the device
+  dropdown even when the respective feature is disabled, making
+  configuration easier before enabling.
+
+### Changed — Application
+
+- **MIDI Output Notes Updated** — Default MIDI output note assignments have
+  changed from F♯4/G♯4/A♯4 (66/68/70) to G♯5/A♯5/C6 (80/82/84) to match
+  the updated Arduino sketch pin assignments. Existing saved profiles are
+  not affected — only new profiles or factory resets use the new defaults.
+- **Firebase RTDB Field Rename** — The `userName` field has been renamed to
+  `name` and `rtdbOutputUserName` to `rtdbOutputName` throughout the
+  codebase and Firebase protocol for consistency.
+- **Settings Tab Reorder** — The Inputs tab now appears before Outputs in the
+  settings modal (previously Outputs was first).
+- **Audio Output Card Renamed** — "Audio Output" renamed to "Audio Key
+  Output" for clarity.
+
+### Added — Arduino Sketches (v1.1.0)
+
+- **16 Configurable Pins** — Both the ATmega32U4 and nRF52840 sketches now
+  expose all 16 usable GPIO pins as individually configurable slots, each
+  with a direction (input/output), MIDI channel, and MIDI note. The previous
+  3-input / 3-output fixed assignment has been replaced by a fully
+  table-driven configuration at the top of each sketch.
+- **Dual MIDI Channels** — Pins are split across MIDI channel 1 (pins 1–5
+  and 11–13) and channel 2 (pins 6–10 and 14–16), allowing logical grouping
+  of inputs and outputs.
+- **Configurable Debounce** — A `DEBOUNCE_MS` constant (default 5 ms)
+  replaces the hardcoded debounce, allowing easy tuning for different
+  switch types.
+- **Configurable Velocity** — A `MIDI_VELOCITY` constant (default 127)
+  is now exposed for easy adjustment.
+
+### Changed — Arduino Sketches (v1.1.0)
+
+- **Output Pin Numbers Changed** — Output pins have moved from
+  **5, 6, 7** (GPIO) to **14, 15, A0** (ATmega32U4) / **P1.11, P1.13,
+  P0.02** (nRF52840). The physical pin positions on the board are now
+  pins 11–16 instead of pins 4–6.
+- **Output MIDI Notes Changed** — Output notes have changed from
+  F♯4/G♯4/A♯4 (66/68/70) to G♯5/A♯5/C6 (80/82/84) on channel 1, with
+  three additional outputs on D6/E6/F♯6 (86/88/90) on channel 2.
+- **Input MIDI Notes Changed** — Input notes have expanded from
+  C4/D4/E4 (60/62/64) on channel 1 to ten inputs spanning
+  C4–F♯5 (60–78) across channels 1 and 2.
+
+### ⚠️ Arduino Sketch Compatibility
+
+> **Breaking change for output wiring.** If you are upgrading from the
+> v1.0.0 Arduino sketch, **input wiring on pins 2, 3, and 4 will continue
+> to work** — these pins remain inputs with the same MIDI notes (60, 62,
+> 64). However, **output wiring must be moved** from the old pins (5, 6, 7)
+> to the new pins (14, 15, A0 on ATmega32U4 / the corresponding nRF52840
+> GPIOs). The MIDI output notes have also changed from 66/68/70 to
+> 80/82/84, so **MIDI Output mappings in Morse Code Studio must be
+> updated** to match (new profiles already use the correct defaults).
+>
+> **Reprogramming the Arduino is required.** Upload the new v1.1.0 sketch,
+> then rewire output connections to the new pin positions.
+
+---
+
 ## [1.0.0] - 2026-03-08
 
 First official public release of Morse Code Studio as an open-source project under the CC0-1.0 Universal license.

--- a/Firebase_RTDB_Setup.md
+++ b/Firebase_RTDB_Setup.md
@@ -59,11 +59,11 @@ const firebaseConfig = {
           "$secret": {
             ".read": true,
             ".write": true,
-            ".validate": "newData.hasChildren(['char', 'userName', 'ts', 'wpm'])
+            ".validate": "newData.hasChildren(['char', 'name', 'ts', 'wpm'])
                           && newData.child('char').isString()
                           && newData.child('char').val().length <= 5
-                          && newData.child('userName').isString()
-                          && newData.child('userName').val().length <= 20
+                          && newData.child('name').isString()
+                          && newData.child('name').val().length <= 20
                           && newData.child('ts').val() === now
             							&& newData.child('wpm').isNumber()
             							&& newData.child('wpm').val() >= 5

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Connect a physical key or paddle, and decoded Morse code appears instantly on a 
 
 **Encode** — Converts typed text into perfectly timed Morse code audio. Supports "Send on Enter" (compose then send) and "Live" (send as you type) modes.
 
-**Key** — Five keyer modes: straight key, Iambic A, Iambic B, Ultimatic, and Single Lever, with full dit/dah memory and per-keyer reverse paddles. Input from an Arduino MIDI paddle interface, USB-serial adapter (DSR/CTS/DCD/RI via Web Serial API), computer keyboard, mouse, or touchscreen. Experimental: physical key input via microphone with ultrasonic pilot-tone detection.
+**Key** — Five keyer modes: straight key, Iambic A, Iambic B, Ultimatic, and Single Lever, with full dit/dah memory and per-keyer reverse paddles. Input from an Arduino MIDI paddle interface (multiple mappings with independent settings), USB-serial adapter (DSR/CTS/DCD/RI via Web Serial API), computer keyboard, mouse, or touchscreen. MIDI input supports optional **Name** and **Colour** per mapping for multi-user conversation views. Experimental: physical key input via microphone with ultrasonic pilot-tone detection.
 
-**Key Your Radio** — Drives your transmitter's keying line through multiple output methods: Arduino MIDI optocoupler, sound card optocoupler (DC or AC mode), USB-serial adapter (DTR/RTS via Web Serial API), or WinKeyer.
+**Key Your Radio** — Drives your transmitter's keying line through multiple output methods: Arduino MIDI optocoupler (multiple mappings with per-mapping forward selectors), sound card optocoupler (DC or AC mode), USB-serial adapter (DTR/RTS via Web Serial API), or WinKeyer.
 
 **Online Relay** — Relay Morse characters between app instances in real time over the internet via Firebase Realtime Database. Each character carries the sender's WPM so the receiving station plays it back at the original rhythm. Channels use a name + secret pair for access control, with callsign-prefixed lines in the fullscreen conversation view.
 
@@ -26,9 +26,11 @@ The app supports several hardware interfaces for physical key input and transmit
 
 ### Arduino MIDI (Recommended)
 
-The **preferred interface** is a simple Arduino-based USB MIDI adapter. An Arduino Pro Micro (ATmega32U4 or nRF52840) enumerates as a standard USB MIDI device — no drivers needed — and provides both **paddle/key input** and **optocoupler keying output** over a single USB connection. The Web MIDI API delivers input events asynchronously (no polling), so timing is crisp and responsive even at high WPM. Crucially, **MIDI works when the browser is in the background or minimised**, unlike keyboard and mouse keyers which require the app to be in focus. This makes MIDI the most practical interface for on-air use where you may need to switch between applications while operating.
+The **preferred interface** is a simple Arduino-based USB MIDI adapter. An Arduino Pro Micro (ATmega32U4 or nRF52840) enumerates as a standard USB MIDI device — no drivers needed — and provides both **paddle/key input** and **optocoupler keying output** over a single USB connection. The v1.1.0 sketches support **16 configurable pins** (10 inputs and 6 outputs by default) across two MIDI channels. The Web MIDI API delivers input events asynchronously (no polling), so timing is crisp and responsive even at high WPM. Crucially, **MIDI works when the browser is in the background or minimised**, unlike keyboard and mouse keyers which require the app to be in focus. This makes MIDI the most practical interface for on-air use where you may need to switch between applications while operating.
 
 The [`arduino/`](arduino/) folder contains ready-made sketches for both board variants, with wiring diagrams for straight keys, iambic paddles, and optocoupler output circuits. See the [Arduino README](arduino/README.md) for build details.
+
+Multiple MIDI devices can be used simultaneously — each MIDI Input and MIDI Output mapping is independently configurable with its own device, channel, notes, and routing. MIDI Input mappings also support optional **Name** and **Colour** fields, enabling multi-user conversation views where each operator's decoded text appears on separate colour-coded lines in the fullscreen display.
 
 ### Keyboard, Mouse and Touch
 

--- a/angular.json
+++ b/angular.json
@@ -29,6 +29,7 @@
             "styles": [
               "src/styles.css",
               "src/app/components/settings-modal/settings-shared.css",
+              "src/app/components/settings-modal/settings-inputs-tab/settings-inputs-tab.component.css",
               "src/app/components/settings-modal/settings-outputs-tab/settings-outputs-tab.component.css",
               "src/app/components/settings-modal/settings-other-tab/settings-other-tab.component.css"
             ],
@@ -44,8 +45,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "1.5MB",
-                  "maximumError": "2MB"
+                  "maximumWarning": "2MB",
+                  "maximumError": "2.5MB"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/arduino/Arduino_Pro_Micro_MIDI_Interface/Arduino_Pro_Micro_MIDI_Interface.ino
+++ b/arduino/Arduino_Pro_Micro_MIDI_Interface/Arduino_Pro_Micro_MIDI_Interface.ino
@@ -1,5 +1,6 @@
 /**
  * Arduino Pro Micro MIDI Interface for Morse Code Studio
+ * Version 1.1.0
  *
  * ============================================================
  * OVERVIEW

--- a/arduino/Arduino_Pro_Micro_NRF52840_MIDI_Interface/Arduino_Pro_Micro_NRF52840_MIDI_Interface.ino
+++ b/arduino/Arduino_Pro_Micro_NRF52840_MIDI_Interface/Arduino_Pro_Micro_NRF52840_MIDI_Interface.ino
@@ -1,5 +1,6 @@
 /**
  * Arduino Pro Micro (nRF52840) MIDI Interface for Morse Code Studio
+ * Version 1.1.0
  *
  * ============================================================
  * OVERVIEW

--- a/arduino/README.md
+++ b/arduino/README.md
@@ -22,38 +22,70 @@ Both use the **same pin positions and wiring** — only the software differs.
 
 ---
 
-## Pin assignments
+## ⚠️ Upgrading from v1.0.0
 
-Both board variants use the same pins:
+If you are upgrading from the v1.0.0 sketch (3 inputs + 3 outputs on pins 2–7):
 
-| Pin | Function | Direction | Notes |
-|-----|----------|-----------|-------|
-| 2 | Straight Key | Input | Internal pull-up; short to GND to activate |
-| 3 | Dit Paddle | Input | Internal pull-up; short to GND to activate |
-| 4 | Dah Paddle | Input | Internal pull-up; short to GND to activate |
-| 5 | Straight Key | Output | LOW by default; goes HIGH on MIDI command |
-| 6 | Dit | Output | LOW by default; goes HIGH on MIDI command |
-| 7 | Dah | Output | LOW by default; goes HIGH on MIDI command |
-| GND | Common ground | — | Shared by both inputs and outputs |
+- **Inputs on pins 2, 3, 4 still work** — these pins remain inputs with the same MIDI notes (60, 62, 64). No rewiring needed for keys/paddles.
+- **Outputs have moved** — outputs are no longer on pins 5, 6, 7. They are now on pins 11–16 (GPIO 14, 15, A0, A1, A2, A3 on ATmega32U4). You must **rewire output connections** to the new pins.
+- **Output MIDI notes have changed** — from F♯4/G♯4/A♯4 (66/68/70) to G♯5/A♯5/C6 (80/82/84). Update your **MIDI Output mappings** in Morse Code Studio to match (new profiles already use the correct defaults).
+- **Reprogramming required** — upload the new v1.1.0 sketch to your Arduino.
+
+---
+
+## Pin assignments (v1.1.0)
+
+Both board variants now support **16 configurable pins** — 10 inputs and 6 outputs by default, split across two MIDI channels. Every pin's direction, MIDI channel, and note are fully configurable at the top of each sketch.
+
+| Pin | GPIO (ATmega32U4) | Dir | Ch | Note |
+|-----|-------------------|-----|----|------|
+| 1 | 2 | IN | 1 | C4 (60) |
+| 2 | 3 | IN | 1 | D4 (62) |
+| 3 | 4 | IN | 1 | E4 (64) |
+| 4 | 5 | IN | 1 | F♯4 (66) |
+| 5 | 6 | IN | 1 | G♯4 (68) |
+| 6 | 7 | IN | 2 | A♯4 (70) |
+| 7 | 8 | IN | 2 | C5 (72) |
+| 8 | 9 | IN | 2 | D5 (74) |
+| 9 | 10 | IN | 2 | E5 (76) |
+| 10 | 16 | IN | 2 | F♯5 (78) |
+| 11 | 14 | OUT | 1 | G♯5 (80) |
+| 12 | 15 | OUT | 1 | A♯5 (82) |
+| 13 | A0 | OUT | 1 | C6 (84) |
+| 14 | A1 | OUT | 2 | D6 (86) |
+| 15 | A2 | OUT | 2 | E6 (88) |
+| 16 | A3 | OUT | 2 | F♯6 (90) |
+
+GND is available on both sides of the board.
 
 ### ATmega32U4 Pin Overview
 
 ```mermaid
 flowchart TB
-    subgraph board["Arduino Pro Micro ATmega32U4 — Pin Assignments"]
+    subgraph board["Arduino Pro Micro ATmega32U4 — Pin Assignments (v1.1.0)"]
         direction TB
 
-        subgraph inputs["⬅️ INPUTS  —  active LOW, internal pull-up"]
-            P2["Pin 2 → Straight Key"]
-            P3["Pin 3 → Dit Paddle"]
-            P4["Pin 4 → Dah Paddle"]
+        subgraph inputs["⬅️ INPUTS (10 pins) — active LOW, internal pull-up"]
+            P1["Pin 1: GPIO 2 → Ch1, C4 (60)"]
+            P2["Pin 2: GPIO 3 → Ch1, D4 (62)"]
+            P3["Pin 3: GPIO 4 → Ch1, E4 (64)"]
+            P4["Pin 4: GPIO 5 → Ch1, F#4 (66)"]
+            P5["Pin 5: GPIO 6 → Ch1, G#4 (68)"]
+            P6["Pin 6: GPIO 7 → Ch2, A#4 (70)"]
+            P7["Pin 7: GPIO 8 → Ch2, C5 (72)"]
+            P8["Pin 8: GPIO 9 → Ch2, D5 (74)"]
+            P9["Pin 9: GPIO 10 → Ch2, E5 (76)"]
+            P10["Pin 10: GPIO 16 → Ch2, F#5 (78)"]
             GND_IN["GND → Common ground for keys/paddles"]
         end
 
-        subgraph outputs["➡️ OUTPUTS  —  active HIGH"]
-            P5["Pin 5 → Straight Key Out"]
-            P6["Pin 6 → Dit Out"]
-            P7["Pin 7 → Dah Out"]
+        subgraph outputs["➡️ OUTPUTS (6 pins) — active HIGH"]
+            P11["Pin 11: GPIO 14 → Ch1, G#5 (80)"]
+            P12["Pin 12: GPIO 15 → Ch1, A#5 (82)"]
+            P13["Pin 13: GPIO A0 → Ch1, C6 (84)"]
+            P14["Pin 14: GPIO A1 → Ch2, D6 (86)"]
+            P15["Pin 15: GPIO A2 → Ch2, E6 (88)"]
+            P16["Pin 16: GPIO A3 → Ch2, F#6 (90)"]
             GND_OUT["GND → Common ground for optocouplers"]
         end
 
@@ -73,20 +105,30 @@ The nRF52840 Pro Micro has the same pin layout plus 3 bottom pads (B+, B−, RST
 
 ```mermaid
 flowchart TB
-    subgraph board["Pro Micro nRF52840 — Pin Assignments"]
+    subgraph board["Pro Micro nRF52840 — Pin Assignments (v1.1.0)"]
         direction TB
 
-        subgraph inputs["⬅️ INPUTS  —  active LOW, internal pull-up"]
-            P2["Pin 2 → Straight Key"]
-            P3["Pin 3 → Dit Paddle"]
-            P4["Pin 4 → Dah Paddle"]
+        subgraph inputs["⬅️ INPUTS (10 pins) — active LOW, internal pull-up"]
+            P1["Pin 1: P0.17 → Ch1, C4 (60)"]
+            P2["Pin 2: P0.20 → Ch1, D4 (62)"]
+            P3["Pin 3: P0.22 → Ch1, E4 (64)"]
+            P4["Pin 4: P0.24 → Ch1, F#4 (66)"]
+            P5["Pin 5: P1.00 → Ch1, G#4 (68)"]
+            P6["Pin 6: P0.11 → Ch2, A#4 (70)"]
+            P7["Pin 7: P1.04 → Ch2, C5 (72)"]
+            P8["Pin 8: P1.06 → Ch2, D5 (74)"]
+            P9["Pin 9: P0.09 → Ch2, E5 (76)"]
+            P10["Pin 10: P0.10 → Ch2, F#5 (78)"]
             GND_IN["GND → Common ground for keys/paddles"]
         end
 
-        subgraph outputs["➡️ OUTPUTS  —  active HIGH"]
-            P5["Pin 5 → Straight Key Out"]
-            P6["Pin 6 → Dit Out"]
-            P7["Pin 7 → Dah Out"]
+        subgraph outputs["➡️ OUTPUTS (6 pins) — active HIGH"]
+            P11["Pin 11: P1.11 → Ch1, G#5 (80)"]
+            P12["Pin 12: P1.13 → Ch1, A#5 (82)"]
+            P13["Pin 13: P0.02 → Ch1, C6 (84)"]
+            P14["Pin 14: P0.03 → Ch2, D6 (86)"]
+            P15["Pin 15: P0.28 → Ch2, E6 (88)"]
+            P16["Pin 16: P0.29 → Ch2, F#6 (90)"]
             GND_OUT["GND → Common ground for optocouplers"]
         end
 
@@ -110,16 +152,18 @@ flowchart TB
 
 | Parameter | Value |
 |-----------|-------|
-| Channel | 1 (shown as 0 in some software) |
 | Velocity | 127 |
+| Debounce | 5 ms |
 | **Input** notes (Arduino → PC): | |
-| Straight Key | 60 (C4) |
-| Dit | 62 (D4) |
-| Dah | 64 (E4) |
+| Straight Key (Pin 1) | Ch 1, 60 (C4) |
+| Dit Paddle (Pin 2) | Ch 1, 62 (D4) |
+| Dah Paddle (Pin 3) | Ch 1, 64 (E4) |
+| Pins 4–10 | Ch 1–2, 66–78 (configurable) |
 | **Output** notes (PC → Arduino): | |
-| Straight Key | 66 (F#4) |
-| Dit | 68 (G#4) |
-| Dah | 70 (A#4) |
+| Straight Key (Pin 11) | Ch 1, 80 (G♯5) |
+| Dit (Pin 12) | Ch 1, 82 (A♯5) |
+| Dah (Pin 13) | Ch 1, 84 (C6) |
+| Pins 14–16 | Ch 2, 86–90 (configurable) |
 
 Input and output notes are deliberately different to prevent feedback loops when both MIDI input and MIDI output are enabled on the same device.
 
@@ -131,7 +175,7 @@ All values are configurable at the top of each sketch before uploading.
 
 ### Straight Key Input
 
-Connect a straight key (or any normally-open switch) between **Pin 2** and **GND**. No external resistors are needed — the Arduino's internal pull-up keeps the pin HIGH when the key is open.
+Connect a straight key (or any normally-open switch) between **Pin 1** (GPIO 2) and **GND**. No external resistors are needed — the Arduino's internal pull-up keeps the pin HIGH when the key is open.
 
 ```mermaid
 flowchart LR
@@ -141,7 +185,7 @@ flowchart LR
     end
 
     subgraph board["Arduino Pro Micro"]
-        P2["Pin 2"]
+        P2["Pin 1 (GPIO 2)"]
         GND["GND"]
     end
 
@@ -151,7 +195,7 @@ flowchart LR
 
 ### Iambic Paddle Input
 
-Connect an iambic paddle's **dit** contact to **Pin 3**, **dah** contact to **Pin 4**, and **common** to **GND**.
+Connect an iambic paddle's **dit** contact to **Pin 2** (GPIO 3), **dah** contact to **Pin 3** (GPIO 4), and **common** to **GND**.
 
 ```mermaid
 flowchart LR
@@ -162,8 +206,8 @@ flowchart LR
     end
 
     subgraph board["Arduino Pro Micro"]
-        P3["Pin 3"]
-        P4["Pin 4"]
+        P3["Pin 2 (GPIO 3)"]
+        P4["Pin 3 (GPIO 4)"]
         GND["GND"]
     end
 
@@ -176,12 +220,12 @@ flowchart LR
 
 To key a radio transmitter, connect an output pin through a **220 Ω resistor** to the anode of an optocoupler (e.g. 4N25). The optocoupler's output side connects to the radio's key line, providing electrical isolation.
 
-This diagram shows one channel — repeat for each output pin you need (Pin 5, 6, or 7).
+This diagram shows one channel — repeat for each output pin you need (Pin 11, 12, or 13 on ATmega32U4 / corresponding nRF52840 pins).
 
 ```mermaid
 flowchart LR
     subgraph board["Arduino Pro Micro"]
-        P5["Pin 5 — or 6 / 7"]
+        P5["Pin 11 (GPIO 14) — or 12 / 13"]
         GND["GND"]
     end
 
@@ -234,7 +278,7 @@ flowchart LR
    - **nRF52840:** `Arduino_Pro_Micro_NRF52840_MIDI_Interface/`
 2. Install the required libraries (see above).
 3. Select your board and port under **Tools**.
-4. Review the pin and MIDI configuration constants at the top of the sketch — change them if needed.
+4. Review the pin and MIDI configuration constants at the top of the sketch — all 16 pins are configurable with custom direction, channel, and note.
 5. Upload the sketch.
 6. Wire your key/paddles to the input pins (see diagrams above).
 7. In Morse Code Studio, enable **MIDI Input** and/or **MIDI Output** in Settings and select the Arduino device.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "morse-code-studio",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "morse-code-studio",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@angular/animations": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morse-code-studio",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A browser-based Morse code encoder, decoder and keyer built with Angular and the Web Audio API",
   "author": "5B4AON — Mike",
   "repository": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -175,8 +175,8 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
         for (let i = this.lastTaggedLen; i < tagged.length; i++) {
           const entry = tagged[i];
           // Push to independent display buffers for all entries
-          const userName = this.getDisplayUserName(entry.type, entry.userName);
-          this.displayBuffers.pushDecoded(entry.type, entry.char, userName);
+          const displayName = this.getDisplayName(entry.type, entry.name);
+          this.displayBuffers.pushDecoded(entry.type, entry.char, displayName, entry.color);
 
           // Record input for loop detection (non-RTDB chars are from local inputs)
           if (!entry.fromRtdb) {
@@ -195,19 +195,17 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
           this.winkeyerOutput.forwardDecodedChar(entry.char, entry.type);
 
           // Forward to MIDI output — skip chars that originated from MIDI input
-          // or serial input (prevents echo loops) and skip chars from local
-          // keyer pipelines (keyboard, mouse, touch) because those are already
-          // keyed on the MIDI output in real-time via the decoder's
-          // keyDown/keyUp path.
-          // Only forward chars from audio inputs (mic, CW), encoder, and RTDB.
+          // or serial input (prevents echo loops). Local keyer pipelines
+          // (keyboard, mouse, touch) already fire straight-key notes in
+          // real-time via keyDown/keyUp, so pass paddleOnly=true for those
+          // to avoid double-firing straight-key mappings while still
+          // driving paddle-mode mappings through the character path.
           if (!entry.fromMidi && !entry.fromSerial) {
             const isLocalKeyer = entry.inputPath &&
               (entry.inputPath === 'keyboardStraightKey' || entry.inputPath === 'keyboardPaddle' ||
                entry.inputPath === 'mouseStraightKey' || entry.inputPath === 'mousePaddle' ||
                entry.inputPath === 'touchStraightKey' || entry.inputPath === 'touchPaddle');
-            if (!isLocalKeyer) {
-              this.midiOutput.forwardDecodedChar(entry.char, entry.type, entry.wpm);
-            }
+            this.midiOutput.forwardDecodedChar(entry.char, entry.type, entry.wpm, !!isLocalKeyer);
           }
 
           // Forward to RTDB output only for non-RTDB chars (prevent echo)
@@ -231,11 +229,11 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
         // (buf='', idx=0). Flush any remaining unpushed characters from
         // the old buffer so they reach the display (and prosign actions fire).
         if (buf === '' && this.lastSentBuf && this.lastSentIdx < this.lastSentBuf.length) {
-          const userName = this.getDisplayUserName('tx');
+          const displayName = this.getDisplayName('tx');
           let i = this.lastSentIdx;
           while (i < this.lastSentBuf.length) {
             const { token, endIdx } = this.encoder.extractToken(this.lastSentBuf, i);
-            this.displayBuffers.pushSent(token, userName);
+            this.displayBuffers.pushSent(token, displayName);
             i = endIdx;
           }
         }
@@ -253,13 +251,13 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
         // Enter again). Reset tracking so subsequent advances are picked up.
         this.lastSentIdx = idx;
       } else if (idx > this.lastSentIdx) {
-        const userName = this.getDisplayUserName('tx');
+        const displayName = this.getDisplayName('tx');
         // Walk through newly sent characters using token extraction so
         // prosign patterns (e.g. '<SK>') are pushed as whole strings.
         let i = this.lastSentIdx;
         while (i < idx) {
           const { token, endIdx } = this.encoder.extractToken(buf, i);
-          this.displayBuffers.pushSent(token, userName);
+          this.displayBuffers.pushSent(token, displayName);
           i = endIdx;
         }
         this.lastSentIdx = idx;
@@ -272,8 +270,8 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
     effect(() => {
       const count = this.encoder.wordGapCount();
       if (count > this.lastWordGapCount) {
-        const userName = this.getDisplayUserName('tx');
-        this.displayBuffers.pushSent(' ', userName);
+        const displayName = this.getDisplayName('tx');
+        this.displayBuffers.pushSent(' ', displayName);
       }
       this.lastWordGapCount = count;
     });
@@ -343,10 +341,10 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
 
     // Firebase RTDB incoming characters → decoder display + sidetone only
     this.subs.push(
-      this.rtdbService.incomingChar$.subscribe(({ char, source, userName, wpm }) => {
+      this.rtdbService.incomingChar$.subscribe(({ char, source, name, wpm }) => {
         // Add to decoder tagged output so it appears in conversation / fullscreen
         // Mark fromRtdb so the forwarding effect doesn't echo it back to RTDB
-        this.decoder.taggedOutput.update(arr => [...arr, { type: source, char, userName, fromRtdb: true, wpm }]);
+        this.decoder.taggedOutput.update(arr => [...arr, { type: source, char, name, fromRtdb: true, wpm }]);
         this.decoder.decodedText.update(t => t + char);
         // Play through all outputs whose forward mode matches the source
         // Use remote WPM unless the user has chosen to override with local encoder WPM
@@ -702,19 +700,19 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   /**
-   * Determine the userName prefix for a display buffer entry.
+   * Determine the name prefix for a display buffer entry.
    *
-   * - If the entry already has an RTDB userName (remote sender), use it.
+   * - If the entry already has a name (remote sender or MIDI mapping), use it.
    * - If RTDB output is enabled and the type matches forward mode,
    *   use our own callsign so the local display mirrors the remote view.
    */
-  private getDisplayUserName(type: 'rx' | 'tx', rtdbUserName?: string): string | undefined {
-    if (rtdbUserName) return rtdbUserName;
+  private getDisplayName(type: 'rx' | 'tx', entryName?: string): string | undefined {
+    if (entryName) return entryName;
     const s = this.settings.settings();
-    if (s.rtdbOutputEnabled && s.rtdbOutputUserName.trim()) {
+    if (s.rtdbOutputEnabled && s.rtdbOutputName.trim()) {
       const fwd = s.rtdbOutputForward;
       if (fwd === 'both' || fwd === type) {
-        return s.rtdbOutputUserName.trim();
+        return s.rtdbOutputName.trim();
       }
     }
     return undefined;

--- a/src/app/components/emoji-edit-modal/emoji-edit-modal.component.html
+++ b/src/app/components/emoji-edit-modal/emoji-edit-modal.component.html
@@ -59,7 +59,7 @@
       }
       <span class="actions-spacer"></span>
       <button type="button" class="action-btn cancel-btn" (click)="cancel()">Cancel</button>
-      <button type="button" class="action-btn save-btn" (click)="save()">Save</button>
+      <button type="button" class="action-btn save-btn" (click)="save()">OK</button>
     </div>
   </div>
 </div>

--- a/src/app/components/fullscreen-modal/fs-decoder-view/fs-decoder-view.component.html
+++ b/src/app/components/fullscreen-modal/fs-decoder-view/fs-decoder-view.component.html
@@ -5,9 +5,9 @@
       <!-- Last line: show text inline, then same-source pattern cursor -->
       <span class="fs-line fs-line-inline"
             [style.marginBottom.em]="settings.modalDisplay().lineSpacing"
-            [style.color]="line.type === 'rx' ? settings.modalDisplay().rxForeground : settings.modalDisplay().txForeground"
+            [style.color]="line.color || (line.type === 'rx' ? settings.modalDisplay().rxForeground : settings.modalDisplay().txForeground)"
             [innerHTML]="formatLine(line)"></span><span class="cursor"
-            [style.color]="line.type === 'rx' ? settings.modalDisplay().rxForeground : settings.modalDisplay().txForeground">{{ line.type === 'rx' ? decoder.rxCurrentPattern() : decoder.txCurrentPattern() }}</span>
+            [style.color]="line.color || (line.type === 'rx' ? settings.modalDisplay().rxForeground : settings.modalDisplay().txForeground)">{{ line.type === 'rx' ? decoder.rxCurrentPattern() : decoder.txCurrentPattern() }}</span>
       <!-- Other-source pattern on new line (if any active pattern from opposite direction) -->
       @if (line.type === 'rx' && decoder.txCurrentPattern()) {
         <div><span class="cursor"
@@ -19,7 +19,7 @@
     } @else {
       <div class="fs-line"
            [style.marginBottom.em]="settings.modalDisplay().lineSpacing"
-           [style.color]="line.type === 'rx' ? settings.modalDisplay().rxForeground : settings.modalDisplay().txForeground"
+           [style.color]="line.color || (line.type === 'rx' ? settings.modalDisplay().rxForeground : settings.modalDisplay().txForeground)"
            [innerHTML]="formatLine(line)"></div>
     }
   }

--- a/src/app/components/fullscreen-modal/fs-decoder-view/fs-decoder-view.component.ts
+++ b/src/app/components/fullscreen-modal/fs-decoder-view/fs-decoder-view.component.ts
@@ -24,7 +24,7 @@ import { formatText, formatLine } from '../fullscreen-format.utils';
  * Attaches the mouse keyer to the conversation area so that mouse button
  * presses anywhere in the text area act as morse key input.
  *
- * Text formatting (prosign patterns, emoji replacements, RTDB username prefixes)
+ * Text formatting (prosign patterns, emoji replacements, RTDB name prefixes)
  * is handled by shared utility functions from fullscreen-format.utils.
  */
 @Component({
@@ -117,7 +117,7 @@ export class FsDecoderViewComponent implements OnInit, OnDestroy, OnChanges, Aft
 
   // ---- Text formatting (delegates to shared utility functions) ----
 
-  /** Format a display line with optional username prefix and prosign/emoji styling */
+  /** Format a display line with optional name prefix and prosign/emoji styling */
   formatLine(line: DisplayLine): SafeHtml {
     return formatLine(line, this.settings.settings(), this.sanitizer);
   }

--- a/src/app/components/fullscreen-modal/fs-encoder-view/fs-encoder-view.component.html
+++ b/src/app/components/fullscreen-modal/fs-encoder-view/fs-encoder-view.component.html
@@ -6,9 +6,9 @@
       <!-- RX last line: RX pattern inline, encoder buffer on new line -->
       <span class="fs-line fs-line-inline"
             [style.marginBottom.em]="settings.modalDisplay().lineSpacing"
-            [style.color]="settings.modalDisplay().rxForeground"
+            [style.color]="line.color || settings.modalDisplay().rxForeground"
             [innerHTML]="formatLine(line)"></span><span class="cursor"
-            [style.color]="settings.modalDisplay().rxForeground">{{ decoder.rxCurrentPattern() }}</span>
+            [style.color]="line.color || settings.modalDisplay().rxForeground">{{ decoder.rxCurrentPattern() }}</span>
       @if (decoder.txCurrentPattern()) {
         <div><span class="cursor"
               [style.color]="settings.modalDisplay().txForeground">{{ decoder.txCurrentPattern() }}</span></div>
@@ -25,7 +25,7 @@
       <!-- TX last line: encoder buffer inline, then pattern cursors -->
       <span class="fs-line fs-line-inline"
             [style.marginBottom.em]="settings.modalDisplay().lineSpacing"
-            [style.color]="settings.modalDisplay().txForeground"
+            [style.color]="line.color || settings.modalDisplay().txForeground"
             [innerHTML]="formatLine(line)"></span>@if (encoderPendingChars().length) {<span class="fs-encoder-inline">@for (char of encoderPendingChars(); track $index) {<span
             [class.sending]="$first && encoder.isSending()"
             [style.color]="$first && encoder.isSending()
@@ -41,7 +41,7 @@
       <!-- Non-last line: block -->
       <div class="fs-line"
            [style.marginBottom.em]="settings.modalDisplay().lineSpacing"
-           [style.color]="line.type === 'rx' ? settings.modalDisplay().rxForeground : settings.modalDisplay().txForeground"
+           [style.color]="line.color || (line.type === 'rx' ? settings.modalDisplay().rxForeground : settings.modalDisplay().txForeground)"
            [innerHTML]="formatLine(line)"></div>
     }
   }

--- a/src/app/components/fullscreen-modal/fs-encoder-view/fs-encoder-view.component.ts
+++ b/src/app/components/fullscreen-modal/fs-encoder-view/fs-encoder-view.component.ts
@@ -133,7 +133,7 @@ export class FsEncoderViewComponent implements OnInit, OnDestroy, OnChanges, Aft
 
   // ---- Text formatting (delegates to shared utility functions) ----
 
-  /** Format a display line with optional username prefix and prosign/emoji styling */
+  /** Format a display line with optional name prefix and prosign/emoji styling */
   formatLine(line: DisplayLine): SafeHtml {
     return formatLine(line, this.settings.settings(), this.sanitizer);
   }

--- a/src/app/components/fullscreen-modal/fullscreen-format.utils.ts
+++ b/src/app/components/fullscreen-modal/fullscreen-format.utils.ts
@@ -158,20 +158,20 @@ export function formatTextNoEmoji(text: string, settings: AppSettings, sanitizer
 }
 
 /**
- * Format a complete display line including optional username prefix and text.
+ * Format a complete display line including optional name prefix and text.
  *
- * Username prefixes appear as muted labels before the line content, used for
- * Firebase RTDB relay to identify remote stations.
+ * Name prefixes appear as muted labels before the line content, used for
+ * Firebase RTDB relay and MIDI input mappings to identify sources.
  *
  * @param line The display line to format
  * @param settings Current application settings
  * @param sanitizer Angular DOM sanitizer for safe HTML binding
- * @returns Formatted SafeHtml with optional username prefix and prosign-styled text
+ * @returns Formatted SafeHtml with optional name prefix and prosign-styled text
  */
 export function formatLine(line: DisplayLine, settings: AppSettings, sanitizer: DomSanitizer): SafeHtml {
   let result = '';
-  if (line.userName) {
-    result += `<span class="rtdb-user-prefix">[${escapeHtml(line.userName)}] </span>`;
+  if (line.name) {
+    result += `<span class="rtdb-user-prefix">[${escapeHtml(line.name)}] </span>`;
   }
   result += formatTextInternal(line.text, settings);
   return sanitizer.bypassSecurityTrustHtml(result);

--- a/src/app/components/help/help-ch-inputs.component.html
+++ b/src/app/components/help/help-ch-inputs.component.html
@@ -83,39 +83,107 @@
   engine as the keyboard and mouse keyers.
 </p>
 
-<h3>Settings</h3>
+<h3>Multiple Mappings</h3>
+<p>
+  MIDI Input supports <strong>multiple independent mappings</strong> in a
+  table-based interface. Each mapping defines its own MIDI device, channel,
+  mode (straight key or paddle), note assignments, decoder source (RX/TX),
+  and reverse-paddles toggle. You can:
+</p>
+<ul>
+  <li><strong>Add</strong> a new mapping with the <strong>+&nbsp;Add</strong>
+      button.</li>
+  <li><strong>Edit</strong> any mapping via the pencil button to open the
+      edit modal.</li>
+  <li><strong>Duplicate</strong> an existing mapping as a starting point for
+      a new one.</li>
+  <li><strong>Remove</strong> a mapping with the delete button.</li>
+  <li><strong>Enable / disable</strong> individual mappings with the
+      checkbox.</li>
+</ul>
+<p>
+  This allows you to connect several MIDI devices simultaneously &mdash;
+  for example, one operator on a MIDI paddle and another on a MIDI foot
+  switch &mdash; each with independent settings and decoder source
+  routing.
+</p>
+
+<h3>Name &amp; Colour (Multi-User Conversations)</h3>
+<p>
+  Each mapping has optional <strong>Name</strong> and
+  <strong>Colour</strong> fields. When a name is set (e.g. a callsign
+  or operator name):
+</p>
+<ul>
+  <li>Decoded text from that mapping appears on a <strong>new line</strong>
+      in the fullscreen conversation views, prefixed with
+      <strong>[Name]</strong> &mdash; the same format used by Firebase RTDB
+      user names.</li>
+  <li>If a colour is set, the text is rendered in that colour instead of the
+      default RX or TX colour.</li>
+  <li>If no colour is set, the mapping uses the default RX colour (light
+      blue) or TX colour (light orange) based on the source assignment.</li>
+</ul>
+<p>
+  This feature enables <strong>multi-user conversation views</strong>: connect
+  two or more MIDI keys or paddles (e.g. two Arduino Pro Micros), assign each
+  mapping a different name and colour, and the fullscreen decoder view
+  displays each operator&rsquo;s text on separate colour-coded lines &mdash;
+  ideal for live demonstrations, training sessions, or two-person practice
+  where both operators&rsquo; morse is decoded and displayed simultaneously
+  on a single screen.
+</p>
+
+<h3>Settings (per mapping)</h3>
 <ul>
   <li><strong>MIDI Device</strong> &mdash; Select a specific MIDI input, or
       leave on &ldquo;Any&rdquo; to accept messages from the first available
       device.</li>
   <li><strong>MIDI Channel</strong> &mdash; Filter by MIDI channel (1&ndash;16),
       or &ldquo;Omni&rdquo; to accept all channels.</li>
-  <li><strong>Straight Key</strong> &mdash; Click the capture button and press
-      a key/pad on your MIDI controller. That note will act as a straight
-      key (press = key down, release = key up).</li>
-  <li><strong>Dit Paddle</strong> &mdash; Capture a MIDI note for the dit
-      paddle. Used with iambic keyer modes.</li>
-  <li><strong>Dah Paddle</strong> &mdash; Capture a MIDI note for the dah
-      paddle.</li>
+  <li><strong>Mode</strong> &mdash; Straight key or Paddle.</li>
+  <li><strong>Note</strong> &mdash; The MIDI note for straight key or dit
+      paddle. Use the capture button or note/octave picker.</li>
+  <li><strong>Dah Note</strong> &mdash; (Paddle mode only) The MIDI note for
+      the dah paddle.</li>
   <li><strong>Reverse Paddles</strong> &mdash; Swap dit and dah paddle
       assignments.</li>
-  <li><strong>Paddle Mode</strong> &mdash; Iambic A, Iambic B, Ultimatic,
-      or Single Lever (shared with keyboard and mouse keyers).</li>
   <li><strong>Used for</strong> &mdash; Decoder source (RX or TX). See
       <em>Chapter 5: Decoder Source Routing</em>.</li>
+  <li><strong>Name</strong> &mdash; Optional display name (e.g. callsign).
+      Triggers line breaks in fullscreen conversation views.</li>
+  <li><strong>Colour</strong> &mdash; Optional text colour for fullscreen
+      views. Overrides the default RX/TX colour.</li>
 </ul>
 
 <div class="example-box">
   <div class="example-title">Assigning MIDI notes</div>
   <p>
     1. Enable MIDI Input and expand the settings card.<br>
-    2. Click the &ldquo;Straight Key&rdquo; capture button &mdash; it shows
-    &ldquo;Press a MIDI key&hellip;&rdquo;.<br>
-    3. Press the desired key or pedal on your MIDI controller.<br>
-    4. The button updates to show the captured note name (e.g.
-    &ldquo;C4 (60)&rdquo;).<br>
-    5. Repeat for Dit and Dah paddles if using paddle mode.<br>
-    6. Click the &times; button next to any assignment to clear it.
+    2. Click the pencil (edit) button on a mapping row to open the
+    edit modal.<br>
+    3. Select your MIDI device and channel. Choose straight key or
+    paddle mode.<br>
+    4. Use the note/octave picker or click the capture button and press
+    the desired key or pedal on your MIDI controller. The button updates
+    to show the captured note (e.g. &ldquo;C4 (60)&rdquo;).<br>
+    5. Repeat for the dah paddle note if using paddle mode.<br>
+    6. Click <strong>Save</strong> to apply the mapping.
+  </p>
+</div>
+
+<div class="example-box">
+  <div class="example-title">Multi-user demonstration setup</div>
+  <p>
+    Connect two Arduino Pro Micros, each with a paddle attached. Add two
+    MIDI input mappings &mdash; one per Arduino. Set each mapping to a
+    different MIDI device, assign a <strong>Name</strong> (e.g. the
+    operator&rsquo;s callsign) and a <strong>Colour</strong> (e.g. cyan
+    for one, orange for the other). Open the fullscreen decoder view.
+    Both operators can key simultaneously, and each operator&rsquo;s
+    decoded text appears on separate colour-coded lines with their name
+    prefix &mdash; perfect for live events, training, or CW practice
+    with a partner.
   </p>
 </div>
 
@@ -221,13 +289,13 @@
   <p>
     The project includes ready-made Arduino sketches (in the
     <code>arduino/</code> folder of the source repository) that turn a
-    Pro Micro into a USB MIDI device with straight key and paddle inputs
-    on pins 2, 3 and 4. Two board variants are provided: <strong>ATmega32U4</strong>
-    (classic Pro Micro, using the MIDIUSB library) and <strong>nRF52840</strong>
-    (Supermini / nice!nano, using Adafruit TinyUSB). Flash the sketch,
-    connect your key or paddles, and the Arduino appears as a standard
-    MIDI device &mdash; no drivers needed. Wiring diagrams and setup
-    instructions are included.
+    Pro Micro into a USB MIDI device with up to 16 configurable pins for
+    inputs and outputs. Two board variants are provided:
+    <strong>ATmega32U4</strong> (classic Pro Micro, using the MIDIUSB
+    library) and <strong>nRF52840</strong> (Supermini / nice!nano, using
+    Adafruit TinyUSB). Flash the sketch, connect your key or paddles,
+    and the Arduino appears as a standard MIDI device &mdash; no drivers
+    needed. Wiring diagrams and setup instructions are included.
   </p>
 </div>
 

--- a/src/app/components/help/help-ch-outputs.component.html
+++ b/src/app/components/help/help-ch-outputs.component.html
@@ -357,6 +357,47 @@
   the output produces properly timed morse elements.
 </p>
 
+<h3>Multiple Mappings</h3>
+<p>
+  MIDI Output supports <strong>multiple independent mappings</strong> in a
+  table-based interface (the same pattern as MIDI Input &sect;6.2). Each
+  mapping defines its own MIDI device, channel, mode (straight key or
+  paddle), note assignments, and <strong>forward selector</strong>. You can:
+</p>
+<ul>
+  <li><strong>Add</strong> a new mapping with the <strong>+&nbsp;Add</strong>
+      button.</li>
+  <li><strong>Edit</strong> any mapping via the pencil button to open the
+      edit modal.</li>
+  <li><strong>Duplicate</strong> an existing mapping as a starting point.</li>
+  <li><strong>Remove</strong> a mapping with the delete button.</li>
+  <li><strong>Enable / disable</strong> individual mappings with the
+      checkbox.</li>
+</ul>
+<p>
+  This allows you to drive multiple MIDI devices (or multiple channels on
+  the same device) simultaneously &mdash; for example, one mapping keying a
+  transmitter via an Arduino optocoupler on channel 1, while another mapping
+  drives an LED indicator on channel 2.
+</p>
+
+<h3>Per-Mapping Forward Selector</h3>
+<p>
+  Each mapping has its own <strong>Forward</strong> setting that controls
+  which signal sources drive it:
+</p>
+<ul>
+  <li><strong>TX only</strong> (default) &mdash; Fires only for transmitted
+      morse (encoder, keyer inputs tagged as TX).</li>
+  <li><strong>RX only</strong> &mdash; Fires only for received morse
+      (decoded audio inputs, Firebase RTDB).</li>
+  <li><strong>Both</strong> &mdash; Fires for all morse activity.</li>
+</ul>
+<p>
+  This per-mapping control lets you route RX and TX to different MIDI
+  devices or channels independently.
+</p>
+
 <h3>All Input Sources Supported</h3>
 <p>
   MIDI output works with <strong>every input type</strong>:
@@ -397,27 +438,31 @@
   MIDIUSB) and the nRF52840 variant (Supermini / nice!nano, using
   Adafruit TinyUSB) are included in the <code>arduino/</code> folder of
   the source repository, along with wiring diagrams and setup instructions.
+  The v1.1.0 sketches support <strong>16 configurable pins</strong>
+  (10 inputs, 6 outputs by default) across two MIDI channels.
 </p>
 
-<h3>Three Output Notes</h3>
+<h3>Output Modes</h3>
 <p>
-  Each decoded character is broken into its morse elements (dits and dahs).
-  During each element, one or more MIDI notes are held:
+  Each mapping is configured as either <strong>Straight Key</strong> or
+  <strong>Paddle</strong> mode:
 </p>
 <ul>
-  <li><strong>Straight Key</strong> &mdash; Note-on during <em>every</em>
-      element (dit or dah), note-off during the gap between elements.
-      Provides a single "key down / key up" signal for simple keying
-      circuits.</li>
-  <li><strong>Dit Paddle</strong> &mdash; Note-on during dit elements only.
-      Allows the Arduino to distinguish dit from dah.</li>
-  <li><strong>Dah Paddle</strong> &mdash; Note-on during dah elements only.</li>
+  <li><strong>Straight Key</strong> &mdash; A single MIDI note fires during
+      <em>every</em> element (dit or dah) and releases during the gap
+      between elements. Provides a simple &ldquo;key down / key up&rdquo;
+      signal for keying circuits.</li>
+  <li><strong>Paddle</strong> &mdash; Two MIDI notes: one for dit elements,
+      one for dah elements. The dit note fires during dit elements, the dah
+      note fires during dah elements. This allows the Arduino to distinguish
+      dit from dah for advanced control (e.g. driving separate paddle
+      jacks).</li>
 </ul>
 <p>
-  During a dit element, both the Straight Key and Dit Paddle notes fire
-  simultaneously. During a dah element, the Straight Key and Dah Paddle
-  notes fire together. The Arduino can use just the straight key note for
-  simple keying, or the individual paddle notes for more advanced control.
+  Both modes can coexist &mdash; you can have a straight-key mapping and
+  a paddle mapping enabled simultaneously. During a dit element, the
+  straight-key note and the dit paddle note fire together. During a dah
+  element, the straight-key note and the dah paddle note fire together.
 </p>
 
 <h3>Independent Lifecycle</h3>
@@ -430,27 +475,26 @@
   output reconnects automatically on page load.
 </p>
 
-<h3>Settings</h3>
+<h3>Settings (per mapping)</h3>
 <ul>
-  <li><strong>Forward</strong> &mdash; Which signal sources drive the MIDI
-      output: TX only, RX only, or Both.</li>
   <li><strong>MIDI Device</strong> &mdash; Select the target MIDI output
       device. &ldquo;Any (first available)&rdquo; uses the first connected
       output.</li>
   <li><strong>MIDI Channel</strong> &mdash; Output channel (1&ndash;16).</li>
-  <li><strong>Velocity</strong> &mdash; Note-on velocity (1&ndash;127).
-      Default is 127 (maximum intensity).</li>
+  <li><strong>Forward</strong> &mdash; Which signal sources drive this
+      mapping: TX only, RX only, or Both.</li>
+  <li><strong>Mode</strong> &mdash; Straight key or Paddle.</li>
+  <li><strong>Note</strong> &mdash; The MIDI note for straight key or dit
+      paddle. Use the note/octave picker or raw 0&ndash;127 entry.</li>
+  <li><strong>Dah Note</strong> &mdash; (Paddle mode only) The MIDI note for
+      the dah paddle.</li>
   <li><strong>Override remote WPM with local encoder WPM</strong> &mdash;
       Characters received via Firebase RTDB carry the sender&rsquo;s original
       WPM speed. By default MIDI output uses that remote speed so the
       playback matches the sender&rsquo;s timing. Enable this option to
       ignore the remote WPM and use your local Encoder WPM instead.</li>
-  <li><strong>Note assignments</strong> &mdash; Each output (Straight Key,
-      Dit Paddle, Dah Paddle) has a configurable MIDI note. Use the
-      note/octave picker or click <strong>#</strong> to switch to raw
-      0&ndash;127 value entry.</li>
-  <li><strong>Test Output</strong> &mdash; Sends a 1-second note-on/off on
-      the Straight Key note to verify the connection.</li>
+  <li><strong>Test</strong> &mdash; Sends a 1-second note-on/off on
+      the mapping&rsquo;s note to verify the connection.</li>
 </ul>
 
 <h3>Browser Requirements</h3>
@@ -498,16 +542,18 @@
 <div class="example-box">
   <div class="example-title">Example — Arduino Pro Micro MIDI keyer</div>
   <p>
-    Flash an Arduino Pro Micro with a MIDIUSB sketch that reads incoming
-    MIDI notes and drives pins 2, 3, and 4 (straight key, dit, dah).
-    In Outputs &rarr; MIDI Output, select the Arduino MIDI device, set
-    Channel 1, and assign notes F&sharp;4 (66), G&sharp;4 (68), A&sharp;4 (70) to the three
-    outputs. Enable MIDI Output. When you send text via the Encoder or
-    key with any input, the decoded characters are played back as properly
-    timed morse elements on the Arduino&rsquo;s output pins.
+    Flash an Arduino Pro Micro with the v1.1.0 MIDIUSB sketch. The sketch
+    drives output pins 11&ndash;16 based on incoming MIDI notes. In
+    Outputs &rarr; MIDI Output, the default mappings already match the
+    Arduino&rsquo;s default output notes: straight key on G&sharp;5 (80)
+    and paddle on A&sharp;5/C6 (82/84), all on channel 1. Select the
+    Arduino MIDI device in each mapping and enable MIDI Output. When you
+    send text via the Encoder or key with any input, the decoded
+    characters are played back as properly timed morse elements on the
+    Arduino&rsquo;s output pins.
   </p>
   <p>
-    <strong>Note:</strong> The output notes (66/68/70) deliberately differ
+    <strong>Note:</strong> The output notes (80/82/84) deliberately differ
     from the input notes (60/62/64) used for MIDI Input (&sect;6.2).
     This prevents a feedback loop when both MIDI Input and MIDI Output
     are enabled on the same device simultaneously.
@@ -521,7 +567,7 @@
     Arduino. The Arduino reads physical paddle switches and sends MIDI
     notes to the app (input on notes 60/62/64), while the app decodes
     those key events into characters and plays them back on different
-    MIDI output notes (66/68/70) to drive an LED, buzzer, or relay.
+    MIDI output notes (80/82/84) to drive an LED, buzzer, or relay.
     Using separate note numbers for input and output prevents feedback
     loops. This creates a complete hardware interface with no serial port
     drivers or custom protocols needed.

--- a/src/app/components/midi-input-edit-modal/midi-input-edit-modal.component.css
+++ b/src/app/components/midi-input-edit-modal/midi-input-edit-modal.component.css
@@ -1,0 +1,369 @@
+/* ===== MIDI Input Edit Modal Overlay ===== */
+.midi-edit-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  animation: midiEditFadeIn .15s ease-out;
+}
+
+@keyframes midiEditFadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Dialog box */
+.midi-edit-dialog {
+  background: #1a1a2a;
+  border: 1px solid #444;
+  border-radius: 12px;
+  width: 100%;
+  max-width: 460px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.6);
+  animation: midiEditSlideIn .15s ease-out;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+@keyframes midiEditSlideIn {
+  from { transform: translateY(-12px) scale(0.97); opacity: 0; }
+  to   { transform: translateY(0) scale(1); opacity: 1; }
+}
+
+/* Header */
+.midi-edit-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.85rem 1.25rem 0.5rem;
+  border-bottom: 1px solid #333;
+}
+
+.midi-edit-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #ffcc00;
+  font-weight: 600;
+}
+
+.close-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid #556;
+  background: #282c34;
+  color: #8cf;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.15s;
+  padding: 0;
+}
+
+.close-btn:hover {
+  background: #3a4050;
+}
+
+.close-btn:active {
+  background: #5577aa;
+  color: #fff;
+  transform: scale(0.88);
+}
+
+/* Body */
+.midi-edit-body {
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.midi-edit-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.midi-edit-label {
+  font-size: 0.85rem;
+  color: #aab;
+  font-weight: 600;
+}
+
+.midi-edit-select {
+  background: #222;
+  color: #ddd;
+  border: 1px solid #555;
+  border-radius: 4px;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.9rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.midi-edit-select:focus {
+  outline: none;
+  border-color: #ffcc00;
+}
+
+/* Note picker row */
+.midi-note-row {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.midi-note-select {
+  background: #222;
+  color: #ddd;
+  border: 1px solid #555;
+  border-radius: 4px;
+  padding: 0.35rem 0.4rem;
+  font-size: 0.85rem;
+  min-width: 55px;
+}
+
+.midi-octave-select {
+  background: #222;
+  color: #ddd;
+  border: 1px solid #555;
+  border-radius: 4px;
+  padding: 0.35rem 0.4rem;
+  font-size: 0.85rem;
+  min-width: 48px;
+}
+
+.midi-note-separator {
+  font-size: 0.8rem;
+  color: #667;
+  padding: 0 0.15rem;
+}
+
+.midi-raw-input {
+  background: #222;
+  color: #ddd;
+  border: 1px solid #555;
+  border-radius: 4px;
+  padding: 0.35rem 0.4rem;
+  font-size: 0.85rem;
+  font-family: monospace;
+  width: 52px;
+  text-align: center;
+}
+
+.midi-raw-input:focus {
+  outline: none;
+  border-color: #ffcc00;
+}
+
+/* Auto-detect button */
+.midi-detect-btn {
+  background: #2a2a3e;
+  border: 1px solid #555;
+  color: #aaa;
+  cursor: pointer;
+  padding: 0.35rem 0.6rem;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.8rem;
+  transition: all 0.15s;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.midi-detect-btn:hover {
+  color: #ffcc00;
+  border-color: #ffcc00;
+  background: #333;
+}
+
+.midi-detect-btn.detecting {
+  color: #ffcc00;
+  border-color: #ffcc00;
+  background: #333;
+  animation: midiDetectPulse 1s infinite;
+}
+
+@keyframes midiDetectPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
+.midi-detect-btn svg {
+  display: block;
+}
+
+.midi-edit-hint {
+  font-size: 0.75rem;
+  color: #667;
+  line-height: 1.3;
+}
+
+.midi-edit-error {
+  color: #f44;
+  font-size: 0.82rem;
+  padding: 0.2rem 0;
+}
+
+/* Text input for Name field */
+.midi-edit-input {
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.9rem;
+  background: #12121e;
+  color: #ddd;
+  border: 1px solid #444;
+  border-radius: 6px;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.midi-edit-input:focus {
+  border-color: #667;
+}
+
+/* Color picker row */
+.midi-color-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.midi-color-picker {
+  width: 36px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid #444;
+  border-radius: 4px;
+  cursor: pointer;
+  background: transparent;
+}
+
+.midi-color-clear {
+  background: transparent;
+  color: #888;
+  border: 1px solid #444;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0.15rem 0.4rem;
+  line-height: 1;
+}
+
+.midi-color-clear:hover {
+  color: #ccc;
+  border-color: #666;
+}
+
+.midi-color-preview {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.midi-edit-checkbox-row label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: #ccc;
+  cursor: pointer;
+}
+
+.midi-edit-checkbox-row input[type="checkbox"] {
+  accent-color: #ffcc00;
+}
+
+/* Actions row */
+.midi-edit-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.65rem 1.25rem 0.85rem;
+  border-top: 1px solid #333;
+}
+
+.actions-spacer {
+  flex: 1;
+}
+
+/* Shared button base */
+.action-btn {
+  padding: 0.45rem 1rem;
+  font-size: 0.88rem;
+  font-weight: 600;
+  border-radius: 6px;
+  border: 1px solid #555;
+  cursor: pointer;
+  transition: background 0.12s, transform 0.08s;
+  min-height: 36px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.action-btn:active {
+  transform: scale(0.96);
+}
+
+/* Cancel button */
+.cancel-btn {
+  background: #282c34;
+  color: #bbc;
+}
+
+.cancel-btn:hover {
+  background: #3a4050;
+}
+
+/* Save button */
+.save-btn {
+  background: #1e4a6e;
+  color: #cdf;
+  border-color: #3a6a9a;
+}
+
+.save-btn:hover {
+  background: #285a80;
+}
+
+/* Delete button */
+.delete-btn {
+  background: #3a2020;
+  color: #faa;
+  border-color: #644;
+}
+
+.delete-btn:hover {
+  background: #4a2a2a;
+  color: #fcc;
+}
+
+.delete-btn svg {
+  display: block;
+}
+
+/* ===== TOUCH IMPROVEMENTS ===== */
+@media (pointer: coarse) {
+  .action-btn {
+    min-height: 44px;
+    padding: 0.55rem 1.3rem;
+    font-size: 0.92rem;
+  }
+
+  .midi-detect-btn {
+    min-height: 40px;
+    padding: 0.4rem 0.8rem;
+  }
+}

--- a/src/app/components/midi-input-edit-modal/midi-input-edit-modal.component.html
+++ b/src/app/components/midi-input-edit-modal/midi-input-edit-modal.component.html
@@ -1,0 +1,173 @@
+<div class="midi-edit-overlay" (click)="cancel()">
+  <div class="midi-edit-dialog" (click)="$event.stopPropagation()" role="dialog"
+       aria-label="Edit MIDI Input Mapping">
+
+    <!-- Header -->
+    <div class="midi-edit-header">
+      <h3>{{ editIndex >= 0 ? 'Edit' : 'Add' }} MIDI Input Mapping</h3>
+      <button type="button" class="close-btn" (click)="cancel()" title="Close">
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+    </div>
+
+    <!-- Body -->
+    <div class="midi-edit-body">
+      <!-- MIDI Device -->
+      <div class="midi-edit-field">
+        <label class="midi-edit-label" for="midiEditDevice">MIDI Device</label>
+        <select id="midiEditDevice" class="midi-edit-select" [(ngModel)]="editDeviceId">
+          <option value="">Any (first available)</option>
+          @for (dev of midiDevices; track dev.id) {
+            <option [value]="dev.id">{{ dev.name }}</option>
+          }
+        </select>
+      </div>
+
+      <!-- MIDI Channel -->
+      <div class="midi-edit-field">
+        <label class="midi-edit-label" for="midiEditChannel">MIDI Channel</label>
+        <select id="midiEditChannel" class="midi-edit-select" [(ngModel)]="editChannel">
+          <option [ngValue]="0">Omni (all channels)</option>
+          @for (ch of midiChannels; track ch) {
+            <option [ngValue]="ch">Channel {{ ch }}</option>
+          }
+        </select>
+      </div>
+
+      <!-- Used for (RX/TX) -->
+      <div class="midi-edit-field">
+        <label class="midi-edit-label" for="midiEditSource">Used for</label>
+        <select id="midiEditSource" class="midi-edit-select" [(ngModel)]="editSource">
+          <option value="rx">RX &mdash; received morse</option>
+          <option value="tx">TX &mdash; transmitted morse</option>
+        </select>
+      </div>
+
+      <!-- Mode (Straight Key / Paddle) -->
+      <div class="midi-edit-field">
+        <label class="midi-edit-label" for="midiEditMode">Mode</label>
+        <select id="midiEditMode" class="midi-edit-select" [(ngModel)]="editMode">
+          <option value="straightKey">Straight Key</option>
+          <option value="paddle">Paddle</option>
+        </select>
+      </div>
+
+      <!-- Value (Straight Key note / Dit note) -->
+      <div class="midi-edit-field">
+        <label class="midi-edit-label">{{ editMode === 'paddle' ? 'Dit Paddle Note' : 'Straight Key Note' }}</label>
+        <div class="midi-note-row">
+          <select class="midi-note-select" [(ngModel)]="editValueNote" (ngModelChange)="onValueNoteChange()">
+            @for (name of noteNames; track $index) {
+              <option [ngValue]="$index">{{ name }}</option>
+            }
+          </select>
+          <select class="midi-octave-select" [(ngModel)]="editValueOctave" (ngModelChange)="onValueOctaveChange()">
+            @for (oct of octaves; track oct) {
+              <option [ngValue]="oct">{{ oct }}</option>
+            }
+          </select>
+          <span class="midi-note-separator">or</span>
+          <input type="number" class="midi-raw-input" min="0" max="127"
+                 [(ngModel)]="editValueRaw" (ngModelChange)="onValueRawChange()"
+                 placeholder="0–127">
+          <button type="button" class="midi-detect-btn"
+                  [class.detecting]="capturing === 'value'"
+                  (click)="onAutoDetect('value')"
+                  title="Auto-detect: press a MIDI key">
+            @if (capturing === 'value') {
+              Press a key…
+            } @else {
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="16"/><line x1="8" y1="12" x2="16" y2="12"/></svg>
+              Detect
+            }
+          </button>
+        </div>
+        <span class="midi-edit-hint">{{ noteDisplay(editValue) }}</span>
+      </div>
+
+      <!-- Dah Value (only for paddle mode) -->
+      @if (editMode === 'paddle') {
+        <div class="midi-edit-field">
+          <label class="midi-edit-label">Dah Paddle Note</label>
+          <div class="midi-note-row">
+            <select class="midi-note-select" [(ngModel)]="editDahNote" (ngModelChange)="onDahNoteChange()">
+              @for (name of noteNames; track $index) {
+                <option [ngValue]="$index">{{ name }}</option>
+              }
+            </select>
+            <select class="midi-octave-select" [(ngModel)]="editDahOctave" (ngModelChange)="onDahOctaveChange()">
+              @for (oct of octaves; track oct) {
+                <option [ngValue]="oct">{{ oct }}</option>
+              }
+            </select>
+            <span class="midi-note-separator">or</span>
+            <input type="number" class="midi-raw-input" min="0" max="127"
+                   [(ngModel)]="editDahValueRaw" (ngModelChange)="onDahRawChange()"
+                   placeholder="0–127">
+            <button type="button" class="midi-detect-btn"
+                    [class.detecting]="capturing === 'dahValue'"
+                    (click)="onAutoDetect('dahValue')"
+                    title="Auto-detect: press a MIDI key">
+              @if (capturing === 'dahValue') {
+                Press a key…
+              } @else {
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="16"/><line x1="8" y1="12" x2="16" y2="12"/></svg>
+                Detect
+              }
+            </button>
+          </div>
+          <span class="midi-edit-hint">{{ noteDisplay(editDahValue) }}</span>
+        </div>
+
+        <!-- Reverse Paddles -->
+        <div class="midi-edit-field midi-edit-checkbox-row">
+          <label>
+            <input type="checkbox" [(ngModel)]="editReversePaddles">
+            Reverse Paddles
+          </label>
+        </div>
+      }
+
+      <!-- Error -->
+      @if (error) {
+        <div class="midi-edit-error">{{ error }}</div>
+      }
+
+      <!-- Name (optional) -->
+      <div class="midi-edit-field">
+        <label class="midi-edit-label" for="midiEditName">Name</label>
+        <input id="midiEditName" type="text" class="midi-edit-input" maxlength="20"
+               [(ngModel)]="editName" placeholder="e.g. callsign (optional)">
+        <span class="midi-edit-hint">Triggers a line break in conversation views when a different name appears.</span>
+      </div>
+
+      <!-- Color (optional) -->
+      <div class="midi-edit-field">
+        <label class="midi-edit-label">Color</label>
+        <div class="midi-color-row">
+          <input type="color" class="midi-color-picker"
+                 [ngModel]="editColor || '#ffffff'"
+                 (ngModelChange)="editColor = $event">
+          @if (editColor) {
+            <button type="button" class="midi-color-clear" (click)="editColor = ''" title="Clear color">✕</button>
+          }
+          <span class="midi-color-preview" [style.color]="editColor || 'inherit'">Sample</span>
+        </div>
+        <span class="midi-edit-hint">Optional. Overrides the default RX/TX colour in fullscreen views. Leave unset to use the standard colours.</span>
+      </div>
+    </div>
+
+    <!-- Actions -->
+    <div class="midi-edit-actions">
+      @if (editIndex >= 0) {
+        <button type="button" class="action-btn delete-btn" (click)="delete()" title="Delete this mapping">
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg>
+          Delete
+        </button>
+      }
+      <span class="actions-spacer"></span>
+      <button type="button" class="action-btn cancel-btn" (click)="cancel()">Cancel</button>
+      <button type="button" class="action-btn save-btn" (click)="save()">OK</button>
+    </div>
+  </div>
+</div>

--- a/src/app/components/midi-input-edit-modal/midi-input-edit-modal.component.ts
+++ b/src/app/components/midi-input-edit-modal/midi-input-edit-modal.component.ts
@@ -1,0 +1,323 @@
+/**
+ * Morse Code Studio
+ */
+
+import { Component, EventEmitter, Input, Output, OnInit, OnDestroy } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MidiInputMapping, MidiInputMode, DecoderSource } from '../../services/settings.service';
+import { MidiInputService, MidiLearnResult, midiNoteName } from '../../services/midi-input.service';
+
+/**
+ * Result payload emitted when the user saves a MIDI input mapping.
+ */
+export interface MidiInputEditSaveEvent {
+  deviceId: string;
+  channel: number;
+  source: DecoderSource;
+  mode: MidiInputMode;
+  value: number;
+  dahValue: number;
+  reversePaddles: boolean;
+  name: string;
+  color: string;
+}
+
+/**
+ * MIDI Input Edit Modal Component
+ *
+ * A modal dialog for creating or editing a single MIDI input mapping.
+ * Contains fields for device, channel, decoder source, mode (straight
+ * key vs paddle), MIDI note values with note/octave pickers and raw
+ * value input, an auto-detect button that captures via MIDI learn,
+ * and a reverse paddles checkbox for paddle mode.
+ */
+@Component({
+  selector: 'app-midi-input-edit-modal',
+  standalone: true,
+  imports: [FormsModule],
+  templateUrl: './midi-input-edit-modal.component.html',
+  styleUrls: ['./midi-input-edit-modal.component.css'],
+})
+export class MidiInputEditModalComponent implements OnInit, OnDestroy {
+  /** The mapping being edited (used to populate initial values) */
+  @Input() mapping: MidiInputMapping = {
+    enabled: true, deviceId: '', channel: 0, source: 'rx',
+    mode: 'straightKey', value: 60, dahValue: -1, reversePaddles: false,
+    name: '', color: '',
+  };
+
+  /** Index of the mapping being edited (-1 for new) */
+  @Input() editIndex = -1;
+
+  /** Available MIDI input devices (passed from parent which has the service) */
+  @Input() midiDevices: { id: string; name: string }[] = [];
+
+  /** All existing mappings — used for duplicate detection */
+  @Input() allMappings: MidiInputMapping[] = [];
+
+  /** Emitted when the user saves the mapping */
+  @Output() saved = new EventEmitter<MidiInputEditSaveEvent>();
+
+  /** Emitted when the user cancels the edit */
+  @Output() cancelled = new EventEmitter<void>();
+
+  /** Emitted when the user deletes the mapping */
+  @Output() deleted = new EventEmitter<void>();
+
+  /** Editable fields */
+  editDeviceId = '';
+  editChannel = 0;
+  editSource: DecoderSource = 'rx';
+  editMode: MidiInputMode = 'straightKey';
+  editValue = 60;
+  editDahValue = 64;
+  editReversePaddles = false;
+  editName = '';
+  editColor = '';
+
+  /** Raw MIDI value inputs (string for binding) */
+  editValueRaw = '60';
+  editDahValueRaw = '64';
+
+  /** Tracked note-name index and octave for dropdowns */
+  editValueNote = 0;
+  editValueOctave = 4;
+  editDahNote = 0;
+  editDahOctave = 4;
+
+  /** Which field is currently in auto-detect/learn mode */
+  capturing: 'value' | 'dahValue' | null = null;
+
+  /** Validation error message */
+  error = '';
+
+  /** Note names for dropdown */
+  readonly noteNames = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+
+  /** Octave range for dropdown (-1 to 9) */
+  readonly octaves = [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+  /** MIDI channel numbers 1–16 for the channel select dropdown */
+  readonly midiChannels = Array.from({ length: 16 }, (_, i) => i + 1);
+
+  constructor(private midiInput: MidiInputService) {}
+
+  ngOnInit(): void {
+    this.editDeviceId = this.mapping.deviceId;
+    this.editChannel = this.mapping.channel;
+    this.editSource = this.mapping.source;
+    this.editMode = this.mapping.mode;
+    this.editValue = this.mapping.value >= 0 ? this.mapping.value : 60;
+    this.editDahValue = this.mapping.dahValue >= 0 ? this.mapping.dahValue : 64;
+    this.editReversePaddles = this.mapping.reversePaddles;
+    this.editName = this.mapping.name || '';
+    this.editColor = this.mapping.color || '';
+    this.editValueRaw = String(this.editValue);
+    this.editDahValueRaw = String(this.editDahValue);
+    this.editValueNote = this.getNoteIndex(this.editValue);
+    this.editValueOctave = this.getOctave(this.editValue);
+    this.editDahNote = this.getNoteIndex(this.editDahValue);
+    this.editDahOctave = this.getOctave(this.editDahValue);
+    this.error = '';
+  }
+
+  ngOnDestroy(): void {
+    if (this.capturing) {
+      this.midiInput.cancelLearn();
+      this.capturing = null;
+    }
+  }
+
+  /** Get the note name component (0-11) from a MIDI note number */
+  getNoteIndex(midiNote: number): number {
+    return midiNote % 12;
+  }
+
+  /** Get the octave from a MIDI note number */
+  getOctave(midiNote: number): number {
+    return Math.floor(midiNote / 12) - 1;
+  }
+
+  /** Convert note index + octave to MIDI note number */
+  toMidiNote(noteIndex: number, octave: number): number {
+    return (octave + 1) * 12 + noteIndex;
+  }
+
+  /** Display a MIDI note as human-readable name */
+  noteDisplay(note: number): string {
+    if (note < 0) return '(none)';
+    return `${midiNoteName(note)} (${note})`;
+  }
+
+  /** Handle note name dropdown change for value field */
+  onValueNoteChange(): void {
+    this.editValue = this.clampMidi(this.toMidiNote(this.editValueNote, this.editValueOctave));
+    this.editValueRaw = String(this.editValue);
+  }
+
+  /** Handle octave dropdown change for value field */
+  onValueOctaveChange(): void {
+    this.editValue = this.clampMidi(this.toMidiNote(this.editValueNote, this.editValueOctave));
+    this.editValueRaw = String(this.editValue);
+  }
+
+  /** Handle raw MIDI value input for value field */
+  onValueRawChange(): void {
+    const v = parseInt(this.editValueRaw, 10);
+    if (!isNaN(v) && v >= 0 && v <= 127) {
+      this.editValue = v;
+      this.editValueNote = this.getNoteIndex(v);
+      this.editValueOctave = this.getOctave(v);
+    }
+  }
+
+  /** Handle note name dropdown change for dah value field */
+  onDahNoteChange(): void {
+    this.editDahValue = this.clampMidi(this.toMidiNote(this.editDahNote, this.editDahOctave));
+    this.editDahValueRaw = String(this.editDahValue);
+  }
+
+  /** Handle octave dropdown change for dah value field */
+  onDahOctaveChange(): void {
+    this.editDahValue = this.clampMidi(this.toMidiNote(this.editDahNote, this.editDahOctave));
+    this.editDahValueRaw = String(this.editDahValue);
+  }
+
+  /** Handle raw MIDI value input for dah value field */
+  onDahRawChange(): void {
+    const v = parseInt(this.editDahValueRaw, 10);
+    if (!isNaN(v) && v >= 0 && v <= 127) {
+      this.editDahValue = v;
+      this.editDahNote = this.getNoteIndex(v);
+      this.editDahOctave = this.getOctave(v);
+    }
+  }
+
+  /** Start auto-detect (MIDI learn) for a field */
+  onAutoDetect(field: 'value' | 'dahValue'): void {
+    if (this.capturing === field) {
+      this.midiInput.cancelLearn();
+      this.capturing = null;
+      return;
+    }
+    this.capturing = field;
+    this.midiInput.startLearn((result: MidiLearnResult) => {
+      if (field === 'value') {
+        this.editValue = result.note;
+        this.editValueRaw = String(result.note);
+        this.editValueNote = this.getNoteIndex(result.note);
+        this.editValueOctave = this.getOctave(result.note);
+      } else {
+        this.editDahValue = result.note;
+        this.editDahValueRaw = String(result.note);
+        this.editDahNote = this.getNoteIndex(result.note);
+        this.editDahOctave = this.getOctave(result.note);
+      }
+      // Auto-fill device and channel if not yet set
+      if (!this.editDeviceId && result.deviceId) {
+        this.editDeviceId = result.deviceId;
+      }
+      if (this.editChannel === 0 && result.channel > 0) {
+        this.editChannel = result.channel;
+      }
+      this.capturing = null;
+    });
+  }
+
+  /** Save the edited mapping after validation */
+  save(): void {
+    const value = this.editValue;
+    const dahValue = this.editMode === 'paddle' ? this.editDahValue : -1;
+
+    if (value < 0 || value > 127) {
+      this.error = 'MIDI note value must be 0–127.';
+      return;
+    }
+    if (this.editMode === 'paddle' && (dahValue < 0 || dahValue > 127)) {
+      this.error = 'Dah paddle MIDI note value must be 0–127.';
+      return;
+    }
+    if (this.editMode === 'paddle' && value === dahValue) {
+      this.error = 'Dit and dah paddle notes must be different.';
+      return;
+    }
+
+    // Duplicate detection: device + channel + note must be unique
+    const dupError = this.checkDuplicates(value, dahValue);
+    if (dupError) {
+      this.error = dupError;
+      return;
+    }
+
+    this.saved.emit({
+      deviceId: this.editDeviceId,
+      channel: this.editChannel,
+      source: this.editSource,
+      mode: this.editMode,
+      value,
+      dahValue,
+      reversePaddles: this.editMode === 'paddle' ? this.editReversePaddles : false,
+      name: this.editName.trim(),
+      color: this.editColor,
+    });
+  }
+
+  /**
+   * Check whether any note in this mapping conflicts with an existing mapping's
+   * notes on the same device + channel combination. Returns an error message
+   * if a conflict is found, or empty string if clear.
+   *
+   * Two notes conflict when they share the same MIDI note number AND their
+   * device/channel filters overlap (both 'any', or same specific device; both
+   * omni, or same specific channel).
+   */
+  private checkDuplicates(value: number, dahValue: number): string {
+    const myNotes = [value];
+    if (dahValue >= 0) myNotes.push(dahValue);
+
+    for (let i = 0; i < this.allMappings.length; i++) {
+      if (i === this.editIndex) continue; // skip self
+      const other = this.allMappings[i];
+
+      // Device overlap: both 'any', or either is 'any', or same specific ID
+      const deviceOverlap = !this.editDeviceId || !other.deviceId
+        || this.editDeviceId === other.deviceId;
+      if (!deviceOverlap) continue;
+
+      // Channel overlap: both omni, or either is omni, or same channel
+      const channelOverlap = this.editChannel === 0 || other.channel === 0
+        || this.editChannel === other.channel;
+      if (!channelOverlap) continue;
+
+      // Collect the other mapping's notes
+      const otherNotes = [other.value];
+      if (other.mode === 'paddle' && other.dahValue >= 0) otherNotes.push(other.dahValue);
+
+      for (const n of myNotes) {
+        if (otherNotes.includes(n)) {
+          return `Note ${midiNoteName(n)} (${n}) conflicts with mapping #${i + 1}. Use a different device, channel, or note.`;
+        }
+      }
+    }
+    return '';
+  }
+
+  /** Cancel without saving */
+  cancel(): void {
+    if (this.capturing) {
+      this.midiInput.cancelLearn();
+      this.capturing = null;
+    }
+    this.cancelled.emit();
+  }
+
+  /** Delete this mapping */
+  delete(): void {
+    this.deleted.emit();
+  }
+
+  /** Clamp a MIDI note to valid range */
+  private clampMidi(n: number): number {
+    return Math.max(0, Math.min(127, n));
+  }
+}

--- a/src/app/components/midi-output-edit-modal/midi-output-edit-modal.component.css
+++ b/src/app/components/midi-output-edit-modal/midi-output-edit-modal.component.css
@@ -1,0 +1,274 @@
+/* ===== MIDI Output Edit Modal Overlay ===== */
+.midi-edit-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  animation: midiEditFadeIn .15s ease-out;
+}
+
+@keyframes midiEditFadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Dialog box */
+.midi-edit-dialog {
+  background: #1a1a2a;
+  border: 1px solid #444;
+  border-radius: 12px;
+  width: 100%;
+  max-width: 460px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.6);
+  animation: midiEditSlideIn .15s ease-out;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+@keyframes midiEditSlideIn {
+  from { transform: translateY(-12px) scale(0.97); opacity: 0; }
+  to   { transform: translateY(0) scale(1); opacity: 1; }
+}
+
+/* Header */
+.midi-edit-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.85rem 1.25rem 0.5rem;
+  border-bottom: 1px solid #333;
+}
+
+.midi-edit-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #ffcc00;
+  font-weight: 600;
+}
+
+.close-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid #556;
+  background: #282c34;
+  color: #8cf;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.15s;
+  padding: 0;
+}
+
+.close-btn:hover {
+  background: #3a4050;
+}
+
+.close-btn:active {
+  background: #5577aa;
+  color: #fff;
+  transform: scale(0.88);
+}
+
+/* Body */
+.midi-edit-body {
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.midi-edit-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.midi-edit-label {
+  font-size: 0.85rem;
+  color: #aab;
+  font-weight: 600;
+}
+
+.midi-edit-select {
+  background: #222;
+  color: #ddd;
+  border: 1px solid #555;
+  border-radius: 4px;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.9rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.midi-edit-select:focus {
+  outline: none;
+  border-color: #ffcc00;
+}
+
+/* Note picker row */
+.midi-note-row {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.midi-note-select {
+  background: #222;
+  color: #ddd;
+  border: 1px solid #555;
+  border-radius: 4px;
+  padding: 0.35rem 0.4rem;
+  font-size: 0.85rem;
+  min-width: 55px;
+}
+
+.midi-octave-select {
+  background: #222;
+  color: #ddd;
+  border: 1px solid #555;
+  border-radius: 4px;
+  padding: 0.35rem 0.4rem;
+  font-size: 0.85rem;
+  min-width: 48px;
+}
+
+.midi-note-separator {
+  font-size: 0.8rem;
+  color: #667;
+  padding: 0 0.15rem;
+}
+
+.midi-raw-input {
+  background: #222;
+  color: #ddd;
+  border: 1px solid #555;
+  border-radius: 4px;
+  padding: 0.35rem 0.4rem;
+  font-size: 0.85rem;
+  font-family: monospace;
+  width: 52px;
+  text-align: center;
+}
+
+.midi-raw-input:focus {
+  outline: none;
+  border-color: #ffcc00;
+}
+
+.midi-edit-hint {
+  font-size: 0.75rem;
+  color: #667;
+  line-height: 1.3;
+}
+
+.midi-edit-error {
+  color: #f44;
+  font-size: 0.82rem;
+  padding: 0.2rem 0;
+}
+
+/* Test mapping button */
+.test-mapping-btn {
+  background: #1e3a4e;
+  color: #8cf;
+  border-color: #3a5a7a;
+  align-self: flex-start;
+}
+
+.test-mapping-btn:hover:not(:disabled) {
+  background: #285a70;
+}
+
+.test-mapping-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Actions row */
+.midi-edit-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.65rem 1.25rem 0.85rem;
+  border-top: 1px solid #333;
+}
+
+.actions-spacer {
+  flex: 1;
+}
+
+/* Shared button base */
+.action-btn {
+  padding: 0.45rem 1rem;
+  font-size: 0.88rem;
+  font-weight: 600;
+  border-radius: 6px;
+  border: 1px solid #555;
+  cursor: pointer;
+  transition: background 0.12s, transform 0.08s;
+  min-height: 36px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.action-btn:active {
+  transform: scale(0.96);
+}
+
+/* Cancel button */
+.cancel-btn {
+  background: #282c34;
+  color: #bbc;
+}
+
+.cancel-btn:hover {
+  background: #3a4050;
+}
+
+/* Save button */
+.save-btn {
+  background: #1e4a6e;
+  color: #cdf;
+  border-color: #3a6a9a;
+}
+
+.save-btn:hover {
+  background: #285a80;
+}
+
+/* Delete button */
+.delete-btn {
+  background: #3a2020;
+  color: #faa;
+  border-color: #644;
+}
+
+.delete-btn:hover {
+  background: #4a2a2a;
+  color: #fcc;
+}
+
+.delete-btn svg {
+  display: block;
+}
+
+/* ===== TOUCH IMPROVEMENTS ===== */
+@media (pointer: coarse) {
+  .action-btn {
+    min-height: 44px;
+    padding: 0.55rem 1.3rem;
+    font-size: 0.92rem;
+  }
+}

--- a/src/app/components/midi-output-edit-modal/midi-output-edit-modal.component.html
+++ b/src/app/components/midi-output-edit-modal/midi-output-edit-modal.component.html
@@ -1,0 +1,127 @@
+<div class="midi-edit-overlay" (click)="cancel()">
+  <div class="midi-edit-dialog" (click)="$event.stopPropagation()" role="dialog"
+       aria-label="Edit MIDI Output Mapping">
+
+    <!-- Header -->
+    <div class="midi-edit-header">
+      <h3>{{ editIndex >= 0 ? 'Edit' : 'Add' }} MIDI Output Mapping</h3>
+      <button type="button" class="close-btn" (click)="cancel()" title="Close">
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+    </div>
+
+    <!-- Body -->
+    <div class="midi-edit-body">
+      <!-- MIDI Device -->
+      <div class="midi-edit-field">
+        <label class="midi-edit-label" for="midiOutEditDevice">MIDI Device</label>
+        <select id="midiOutEditDevice" class="midi-edit-select" [(ngModel)]="editDeviceId">
+          <option value="">Any (first available)</option>
+          @for (dev of midiDevices; track dev.id) {
+            <option [value]="dev.id">{{ dev.name }}</option>
+          }
+        </select>
+      </div>
+
+      <!-- MIDI Channel -->
+      <div class="midi-edit-field">
+        <label class="midi-edit-label" for="midiOutEditChannel">MIDI Channel</label>
+        <select id="midiOutEditChannel" class="midi-edit-select" [(ngModel)]="editChannel">
+          @for (ch of midiChannels; track ch) {
+            <option [ngValue]="ch">Channel {{ ch }}</option>
+          }
+        </select>
+      </div>
+
+      <!-- Forward -->
+      <div class="midi-edit-field">
+        <label class="midi-edit-label" for="midiOutEditForward">Forward</label>
+        <select id="midiOutEditForward" class="midi-edit-select" [(ngModel)]="editForward">
+          <option value="tx">TX only &mdash; transmitted morse</option>
+          <option value="rx">RX only &mdash; received morse</option>
+          <option value="both">Both RX and TX</option>
+        </select>
+      </div>
+
+      <!-- Mode (Straight Key / Paddle) -->
+      <div class="midi-edit-field">
+        <label class="midi-edit-label" for="midiOutEditMode">Mode</label>
+        <select id="midiOutEditMode" class="midi-edit-select" [(ngModel)]="editMode">
+          <option value="straightKey">Straight Key</option>
+          <option value="paddle">Paddle</option>
+        </select>
+      </div>
+
+      <!-- Value (Straight Key note / Dit note) -->
+      <div class="midi-edit-field">
+        <label class="midi-edit-label">{{ editMode === 'paddle' ? 'Dit Paddle Note' : 'Straight Key Note' }}</label>
+        <div class="midi-note-row">
+          <select class="midi-note-select" [(ngModel)]="editValueNote" (ngModelChange)="onValueNoteChange()">
+            @for (name of noteNames; track $index) {
+              <option [ngValue]="$index">{{ name }}</option>
+            }
+          </select>
+          <select class="midi-octave-select" [(ngModel)]="editValueOctave" (ngModelChange)="onValueOctaveChange()">
+            @for (oct of octaves; track oct) {
+              <option [ngValue]="oct">{{ oct }}</option>
+            }
+          </select>
+          <span class="midi-note-separator">or</span>
+          <input type="number" class="midi-raw-input" min="0" max="127"
+                 [(ngModel)]="editValueRaw" (ngModelChange)="onValueRawChange()"
+                 placeholder="0–127">
+        </div>
+        <span class="midi-edit-hint">{{ noteDisplay(editValue) }}</span>
+      </div>
+
+      <!-- Dah Value (only for paddle mode) -->
+      @if (editMode === 'paddle') {
+        <div class="midi-edit-field">
+          <label class="midi-edit-label">Dah Paddle Note</label>
+          <div class="midi-note-row">
+            <select class="midi-note-select" [(ngModel)]="editDahNote" (ngModelChange)="onDahNoteChange()">
+              @for (name of noteNames; track $index) {
+                <option [ngValue]="$index">{{ name }}</option>
+              }
+            </select>
+            <select class="midi-octave-select" [(ngModel)]="editDahOctave" (ngModelChange)="onDahOctaveChange()">
+              @for (oct of octaves; track oct) {
+                <option [ngValue]="oct">{{ oct }}</option>
+              }
+            </select>
+            <span class="midi-note-separator">or</span>
+            <input type="number" class="midi-raw-input" min="0" max="127"
+                   [(ngModel)]="editDahValueRaw" (ngModelChange)="onDahRawChange()"
+                   placeholder="0–127">
+          </div>
+          <span class="midi-edit-hint">{{ noteDisplay(editDahValue) }}</span>
+        </div>
+      }
+
+      <!-- Error -->
+      @if (error) {
+        <div class="midi-edit-error">{{ error }}</div>
+      }
+
+      <!-- Test button -->
+      <button type="button" class="action-btn test-mapping-btn"
+              [disabled]="!midiOutput.connected()"
+              (click)="testMapping()">
+        Test Output (1s)
+      </button>
+    </div>
+
+    <!-- Actions -->
+    <div class="midi-edit-actions">
+      @if (editIndex >= 0) {
+        <button type="button" class="action-btn delete-btn" (click)="delete()" title="Delete this mapping">
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg>
+          Delete
+        </button>
+      }
+      <span class="actions-spacer"></span>
+      <button type="button" class="action-btn cancel-btn" (click)="cancel()">Cancel</button>
+      <button type="button" class="action-btn save-btn" (click)="save()">OK</button>
+    </div>
+  </div>
+</div>

--- a/src/app/components/midi-output-edit-modal/midi-output-edit-modal.component.ts
+++ b/src/app/components/midi-output-edit-modal/midi-output-edit-modal.component.ts
@@ -1,0 +1,276 @@
+/**
+ * Morse Code Studio
+ */
+
+import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MidiOutputMapping, MidiOutputMode, OutputForward } from '../../services/settings.service';
+import { MidiOutputService, midiOutputNoteName } from '../../services/midi-output.service';
+
+/**
+ * Result payload emitted when the user saves a MIDI output mapping.
+ */
+export interface MidiOutputEditSaveEvent {
+  deviceId: string;
+  channel: number;
+  forward: OutputForward;
+  mode: MidiOutputMode;
+  value: number;
+  dahValue: number;
+}
+
+/**
+ * MIDI Output Edit Modal Component
+ *
+ * A modal dialog for creating or editing a single MIDI output mapping.
+ * Contains fields for device, channel, mode (straight key vs paddle),
+ * MIDI note values with note/octave pickers and raw value input,
+ * an override-WPM checkbox, and a test output button.
+ * Includes duplicate detection that flags device/channel/note clashes
+ * with other mappings.
+ */
+@Component({
+  selector: 'app-midi-output-edit-modal',
+  standalone: true,
+  imports: [FormsModule],
+  templateUrl: './midi-output-edit-modal.component.html',
+  styleUrls: ['./midi-output-edit-modal.component.css'],
+})
+export class MidiOutputEditModalComponent implements OnInit {
+  /** The mapping being edited (used to populate initial values) */
+  @Input() mapping: MidiOutputMapping = {
+    enabled: true, deviceId: '', channel: 1,
+    forward: 'tx', mode: 'straightKey', value: 80, dahValue: -1,
+  };
+
+  /** Index of the mapping being edited (-1 for new) */
+  @Input() editIndex = -1;
+
+  /** Available MIDI output devices (passed from parent) */
+  @Input() midiDevices: { id: string; name: string }[] = [];
+
+  /** All existing mappings — used for duplicate detection */
+  @Input() allMappings: MidiOutputMapping[] = [];
+
+  /** Emitted when the user saves the mapping */
+  @Output() saved = new EventEmitter<MidiOutputEditSaveEvent>();
+
+  /** Emitted when the user cancels the edit */
+  @Output() cancelled = new EventEmitter<void>();
+
+  /** Emitted when the user deletes the mapping */
+  @Output() deleted = new EventEmitter<void>();
+
+  /** Editable fields */
+  editDeviceId = '';
+  editChannel = 1;
+  editForward: OutputForward = 'tx';
+  editMode: MidiOutputMode = 'straightKey';
+  editValue = 80;
+  editDahValue = 84;
+
+  /** Raw MIDI value inputs (string for binding) */
+  editValueRaw = '80';
+  editDahValueRaw = '84';
+
+  /** Tracked note-name index and octave for dropdowns */
+  editValueNote = 0;
+  editValueOctave = 4;
+  editDahNote = 0;
+  editDahOctave = 4;
+
+  /** Validation error message */
+  error = '';
+
+  /** Note names for dropdown */
+  readonly noteNames = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+
+  /** Octave range for dropdown (-1 to 9) */
+  readonly octaves = [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+  /** MIDI channel numbers 1–16 for the channel select dropdown */
+  readonly midiChannels = Array.from({ length: 16 }, (_, i) => i + 1);
+
+  constructor(public midiOutput: MidiOutputService) {}
+
+  ngOnInit(): void {
+    this.editDeviceId = this.mapping.deviceId;
+    this.editChannel = this.mapping.channel;
+    this.editForward = this.mapping.forward;
+    this.editMode = this.mapping.mode;
+    this.editValue = this.mapping.value >= 0 ? this.mapping.value : 80;
+    this.editDahValue = this.mapping.dahValue >= 0 ? this.mapping.dahValue : 84;
+    this.editValueRaw = String(this.editValue);
+    this.editDahValueRaw = String(this.editDahValue);
+    this.editValueNote = this.getNoteIndex(this.editValue);
+    this.editValueOctave = this.getOctave(this.editValue);
+    this.editDahNote = this.getNoteIndex(this.editDahValue);
+    this.editDahOctave = this.getOctave(this.editDahValue);
+    this.error = '';
+  }
+
+  /** Get the note name component (0-11) from a MIDI note number */
+  getNoteIndex(midiNote: number): number {
+    return midiNote % 12;
+  }
+
+  /** Get the octave from a MIDI note number */
+  getOctave(midiNote: number): number {
+    return Math.floor(midiNote / 12) - 1;
+  }
+
+  /** Convert note index + octave to MIDI note number */
+  toMidiNote(noteIndex: number, octave: number): number {
+    return (octave + 1) * 12 + noteIndex;
+  }
+
+  /** Display a MIDI note as human-readable name */
+  noteDisplay(note: number): string {
+    if (note < 0) return '(none)';
+    return `${midiOutputNoteName(note)} (${note})`;
+  }
+
+  /** Handle note name dropdown change for value field */
+  onValueNoteChange(): void {
+    this.editValue = this.clampMidi(this.toMidiNote(this.editValueNote, this.editValueOctave));
+    this.editValueRaw = String(this.editValue);
+  }
+
+  /** Handle octave dropdown change for value field */
+  onValueOctaveChange(): void {
+    this.editValue = this.clampMidi(this.toMidiNote(this.editValueNote, this.editValueOctave));
+    this.editValueRaw = String(this.editValue);
+  }
+
+  /** Handle raw MIDI value input for value field */
+  onValueRawChange(): void {
+    const v = parseInt(this.editValueRaw, 10);
+    if (!isNaN(v) && v >= 0 && v <= 127) {
+      this.editValue = v;
+      this.editValueNote = this.getNoteIndex(v);
+      this.editValueOctave = this.getOctave(v);
+    }
+  }
+
+  /** Handle note name dropdown change for dah value field */
+  onDahNoteChange(): void {
+    this.editDahValue = this.clampMidi(this.toMidiNote(this.editDahNote, this.editDahOctave));
+    this.editDahValueRaw = String(this.editDahValue);
+  }
+
+  /** Handle octave dropdown change for dah value field */
+  onDahOctaveChange(): void {
+    this.editDahValue = this.clampMidi(this.toMidiNote(this.editDahNote, this.editDahOctave));
+    this.editDahValueRaw = String(this.editDahValue);
+  }
+
+  /** Handle raw MIDI value input for dah value field */
+  onDahRawChange(): void {
+    const v = parseInt(this.editDahValueRaw, 10);
+    if (!isNaN(v) && v >= 0 && v <= 127) {
+      this.editDahValue = v;
+      this.editDahNote = this.getNoteIndex(v);
+      this.editDahOctave = this.getOctave(v);
+    }
+  }
+
+  /** Test this mapping — sends a 1-second pulse on the configured note(s) */
+  async testMapping(): Promise<void> {
+    const channel = this.editChannel;
+    const deviceId = this.editDeviceId;
+    if (this.editMode === 'straightKey') {
+      await this.midiOutput.testMapping(this.editValue, channel, deviceId);
+    } else {
+      await this.midiOutput.testMapping(this.editValue, channel, deviceId);
+    }
+  }
+
+  /** Save the edited mapping after validation */
+  save(): void {
+    const value = this.editValue;
+    const dahValue = this.editMode === 'paddle' ? this.editDahValue : -1;
+
+    if (value < 0 || value > 127) {
+      this.error = 'MIDI note value must be 0–127.';
+      return;
+    }
+    if (this.editMode === 'paddle' && (dahValue < 0 || dahValue > 127)) {
+      this.error = 'Dah paddle MIDI note value must be 0–127.';
+      return;
+    }
+    if (this.editMode === 'paddle' && value === dahValue) {
+      this.error = 'Dit and dah paddle notes must be different.';
+      return;
+    }
+
+    // Duplicate detection: device + channel + note must be unique
+    const dupError = this.checkDuplicates(value, dahValue);
+    if (dupError) {
+      this.error = dupError;
+      return;
+    }
+
+    this.saved.emit({
+      deviceId: this.editDeviceId,
+      channel: this.editChannel,
+      forward: this.editForward,
+      mode: this.editMode,
+      value,
+      dahValue,
+    });
+  }
+
+  /**
+   * Check whether any note in this mapping conflicts with an existing mapping's
+   * notes on the same device + channel combination. Returns an error message
+   * if a conflict is found, or empty string if clear.
+   *
+   * Two notes conflict when they share the same MIDI note number AND their
+   * device/channel filters overlap (both 'any', or same specific device; both
+   * same channel).
+   */
+  private checkDuplicates(value: number, dahValue: number): string {
+    const myNotes = [value];
+    if (dahValue >= 0) myNotes.push(dahValue);
+
+    for (let i = 0; i < this.allMappings.length; i++) {
+      if (i === this.editIndex) continue; // skip self
+      const other = this.allMappings[i];
+
+      // Device overlap: both 'any', or either is 'any', or same specific ID
+      const deviceOverlap = !this.editDeviceId || !other.deviceId
+        || this.editDeviceId === other.deviceId;
+      if (!deviceOverlap) continue;
+
+      // Channel overlap: same channel (output channels are always 1-16, no omni)
+      const channelOverlap = this.editChannel === other.channel;
+      if (!channelOverlap) continue;
+
+      // Collect the other mapping's notes
+      const otherNotes = [other.value];
+      if (other.mode === 'paddle' && other.dahValue >= 0) otherNotes.push(other.dahValue);
+
+      for (const n of myNotes) {
+        if (otherNotes.includes(n)) {
+          return `Note ${midiOutputNoteName(n)} (${n}) conflicts with mapping #${i + 1}. Use a different device, channel, or note.`;
+        }
+      }
+    }
+    return '';
+  }
+
+  /** Cancel without saving */
+  cancel(): void {
+    this.cancelled.emit();
+  }
+
+  /** Delete this mapping */
+  delete(): void {
+    this.deleted.emit();
+  }
+
+  /** Clamp a MIDI note to valid range */
+  private clampMidi(n: number): number {
+    return Math.max(0, Math.min(127, n));
+  }
+}

--- a/src/app/components/settings-modal/settings-inputs-tab/midi-input-card/midi-input-card.component.html
+++ b/src/app/components/settings-modal/settings-inputs-tab/midi-input-card/midi-input-card.component.html
@@ -4,9 +4,8 @@
     <div class="settings-card-title">
       <span class="settings-card-chevron">{{ expanded ? '&#9660;' : '&#9654;' }}</span>
       <span class="settings-card-name">MIDI Input</span>
-      <span class="source-badge" [class.source-rx]="settings.settings().midiStraightKeySource === 'rx'" [class.source-tx]="settings.settings().midiStraightKeySource === 'tx'">{{ settings.settings().midiStraightKeySource === 'rx' ? 'RX' : 'TX' }}</span>
-      @if (settings.settings().midiPaddleSource !== settings.settings().midiStraightKeySource) {
-        <span class="source-badge" [class.source-rx]="settings.settings().midiPaddleSource === 'rx'" [class.source-tx]="settings.settings().midiPaddleSource === 'tx'">{{ settings.settings().midiPaddleSource === 'rx' ? 'RX' : 'TX' }}</span>
+      @for (src of sourceBadges(); track src) {
+        <span class="source-badge" [class.source-rx]="src === 'rx'" [class.source-tx]="src === 'tx'">{{ src === 'rx' ? 'RX' : 'TX' }}</span>
       }
     </div>
     <span class="connectivity-badge" [class.connected]="midiInput.connected()" [class.disconnected]="!midiInput.connected()">
@@ -35,92 +34,35 @@
         <div class="conflict-warning">{{ midiInput.lastError() }}</div>
       }
 
-      <label>MIDI Device:
-        <select [value]="settings.settings().midiInputDeviceId" (change)="onMidiDeviceChange($event)">
-          <option value="">Any (first available)</option>
-          @for (dev of midiInput.midiInputs(); track dev.id) {
-            <option [value]="dev.id" [selected]="dev.id === settings.settings().midiInputDeviceId">{{ dev.name }}</option>
-          }
-        </select>
-      </label>
-
-      <label>MIDI Channel:
-        <select [value]="settings.settings().midiInputChannel" (change)="onSettingChange('midiInputChannel', $event)">
-          <option [value]="0">Omni (all channels)</option>
-          @for (ch of midiChannels; track ch) {
-            <option [value]="ch" [selected]="ch === settings.settings().midiInputChannel">Channel {{ ch }}</option>
-          }
-        </select>
-      </label>
-
-      <div class="card-section-divider">Straight Key</div>
-
-      <label>Used for:
-        <select [value]="settings.settings().midiStraightKeySource" (change)="onSettingChange('midiStraightKeySource', $event)">
-          <option value="rx">RX &mdash; received morse</option>
-          <option value="tx">TX &mdash; transmitted morse</option>
-        </select>
-      </label>
-
-      <label>Straight Key:
-        <button class="key-capture"
-                (click)="onMidiCapture('midiStraightKeyNote')">
-          {{ midiCapturing === 'midiStraightKeyNote' ? 'Press a MIDI key...' : midiNoteDisplay(settings.settings().midiStraightKeyNote) }}
-        </button>
-        @if (settings.settings().midiStraightKeyNote >= 0) {
-          <button class="key-capture-clear" (click)="clearMidiNote('midiStraightKeyNote')" title="Clear">&times;</button>
+      <div class="midi-mapping-list">
+        @for (mapping of settings.settings().midiInputMappings; track $index) {
+          <div class="midi-mapping-row" [class.midi-mapping-row-disabled]="!mapping.enabled">
+            <label class="midi-mapping-enable">
+              <input type="checkbox" [checked]="mapping.enabled"
+                     (change)="onMappingEnabledChange($index, $event)">
+            </label>
+            @if (mapping.name) {
+              <span class="midi-mapping-name" (click)="startEdit($index)" [style.color]="nameColor(mapping)">{{ mapping.name }}</span>
+            }
+            <span class="midi-mapping-mode" (click)="startEdit($index)">{{ mapping.mode === 'straightKey' ? 'Straight' : 'Paddle' }}</span>
+            <span class="midi-mapping-value" (click)="startEdit($index)">{{ mappingSummary(mapping) }}</span>
+            <span class="source-badge source-badge-sm" [class.source-rx]="mapping.source === 'rx'" [class.source-tx]="mapping.source === 'tx'" (click)="startEdit($index)">{{ mapping.source === 'rx' ? 'RX' : 'TX' }}</span>
+            @if (mapping.mode === 'paddle' && mapping.reversePaddles) {
+              <span class="midi-mapping-reverse" (click)="startEdit($index)" title="Paddles reversed">↔</span>
+            }
+            <span class="midi-mapping-spacer"></span>
+            <button class="midi-mapping-btn midi-mapping-btn-edit" (click)="startEdit($index)" title="Edit">
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
+            </button>
+          </div>
         }
-      </label>
-
-      <div class="card-section-divider">Paddle</div>
-
-      <label>Used for:
-        <select [value]="settings.settings().midiPaddleSource" (change)="onSettingChange('midiPaddleSource', $event)">
-          <option value="rx">RX &mdash; received morse</option>
-          <option value="tx">TX &mdash; transmitted morse</option>
-        </select>
-      </label>
-
-      <label>Dit Paddle:
-        <button class="key-capture"
-                (click)="onMidiCapture('midiDitNote')">
-          {{ midiCapturing === 'midiDitNote' ? 'Press a MIDI key...' : midiNoteDisplay(settings.settings().midiDitNote) }}
-        </button>
-        @if (settings.settings().midiDitNote >= 0) {
-          <button class="key-capture-clear" (click)="clearMidiNote('midiDitNote')" title="Clear">&times;</button>
-        }
-      </label>
-
-      <label>Dah Paddle:
-        <button class="key-capture"
-                (click)="onMidiCapture('midiDahNote')">
-          {{ midiCapturing === 'midiDahNote' ? 'Press a MIDI key...' : midiNoteDisplay(settings.settings().midiDahNote) }}
-        </button>
-        @if (settings.settings().midiDahNote >= 0) {
-          <button class="key-capture-clear" (click)="clearMidiNote('midiDahNote')" title="Clear">&times;</button>
-        }
-      </label>
-
-      <label>
-        <input type="checkbox" [checked]="settings.settings().midiReversePaddles"
-               (change)="onBoolChange('midiReversePaddles', $event)">
-        Reverse Paddles
-      </label>
-
-      <label>Paddle Mode:
-        <select [value]="settings.settings().paddleMode" (change)="onSettingChange('paddleMode', $event)">
-          <option value="iambic-b" [selected]="settings.settings().paddleMode === 'iambic-b'">Iambic B</option>
-          <option value="iambic-a" [selected]="settings.settings().paddleMode === 'iambic-a'">Iambic A</option>
-          <option value="ultimatic" [selected]="settings.settings().paddleMode === 'ultimatic'">Ultimatic</option>
-          <option value="single-lever" [selected]="settings.settings().paddleMode === 'single-lever'">Single Lever</option>
-        </select>
-      </label>
+      </div>
+      <button class="midi-mapping-add-btn" (click)="addMapping()">+ Add Mapping</button>
 
       <div class="keyer-hint">
         MIDI input works even when the app is in the background, another window
         is focused, or the screen is locked. Connect a MIDI pedal, keyboard, or
-        controller and assign notes to straight key or paddles using the capture
-        buttons above.
+        controller and assign notes to straight key or paddles.
       </div>
 
       <div class="serial-port-row">
@@ -133,3 +75,16 @@
     </div>
   }
 </div>
+
+<!-- MIDI input edit modal (hosted here because it's triggered from this card) -->
+@if (showEditModal) {
+  <app-midi-input-edit-modal
+    [mapping]="editMapping"
+    [editIndex]="editIndex"
+    [midiDevices]="midiInput.midiInputs()"
+    [allMappings]="settings.settings().midiInputMappings"
+    (saved)="onEditSaved($event)"
+    (cancelled)="onEditCancelled()"
+    (deleted)="onEditDeleted()">
+  </app-midi-input-edit-modal>
+}

--- a/src/app/components/settings-modal/settings-inputs-tab/midi-input-card/midi-input-card.component.ts
+++ b/src/app/components/settings-modal/settings-inputs-tab/midi-input-card/midi-input-card.component.ts
@@ -2,23 +2,24 @@
  * Morse Code Studio
  */
 
-import { Component } from '@angular/core';
+import { Component, computed } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { SettingsService, AppSettings } from '../../../../services/settings.service';
+import { SettingsService, MidiInputMapping, DecoderSource } from '../../../../services/settings.service';
 import { MidiInputService, midiNoteName } from '../../../../services/midi-input.service';
+import { MidiInputEditModalComponent, MidiInputEditSaveEvent } from '../../../midi-input-edit-modal/midi-input-edit-modal.component';
 
 /**
  * Settings card — MIDI Input.
  *
- * Configures MIDI note-on/off as a keying source. Supports straight
- * key and paddle modes with independent note assignments via MIDI
- * learn (capture). Shows device selection, channel filter, connection
- * status badge, and reverse paddles / paddle mode.
+ * Displays a table of MIDI input mappings (straight key / paddle),
+ * with add/edit/delete support via the MIDI input edit modal.
+ * Each mapping has its own device, channel, source, mode, and
+ * note assignments — modelled after the Emojis card pattern.
  */
 @Component({
   selector: 'app-midi-input-card',
   standalone: true,
-  imports: [FormsModule],
+  imports: [FormsModule, MidiInputEditModalComponent],
   templateUrl: './midi-input-card.component.html',
   styles: [':host { display: contents; }'],
 })
@@ -26,32 +27,33 @@ export class MidiInputCardComponent {
   /** Whether this card's body is expanded */
   expanded = false;
 
-  /** Which MIDI setting is currently being captured (`null` = not capturing) */
-  midiCapturing: string | null = null;
+  /** Index of the mapping currently being edited, or -1 for new */
+  editIndex = -1;
 
-  /** MIDI channel numbers 1–16 for the channel select dropdown */
-  readonly midiChannels = Array.from({ length: 16 }, (_, i) => i + 1);
+  /** Scratch copy of the mapping passed to the edit modal */
+  editMapping: MidiInputMapping = {
+    enabled: true, deviceId: '', channel: 0, source: 'rx',
+    mode: 'straightKey', value: 60, dahValue: -1, reversePaddles: false,
+    name: '', color: '',
+  };
+
+  /** Whether the edit modal is visible */
+  showEditModal = false;
+
+  /** Unique source badges from all enabled mappings */
+  readonly sourceBadges = computed(() => {
+    const mappings = this.settings.settings().midiInputMappings;
+    const sources = new Set<DecoderSource>();
+    for (const m of mappings) {
+      if (m.enabled) sources.add(m.source);
+    }
+    return [...sources];
+  });
 
   constructor(
     public settings: SettingsService,
     public midiInput: MidiInputService,
   ) {}
-
-  /** Handle a string or numeric setting change */
-  onSettingChange(key: keyof AppSettings, event: Event): void {
-    const el = event.target as HTMLInputElement;
-    let value: string | number = el.value;
-    if (el.type === 'number' || el.type === 'range') {
-      value = parseFloat(el.value);
-    }
-    this.settings.update({ [key]: value } as Partial<AppSettings>);
-  }
-
-  /** Handle a boolean setting change from a checkbox */
-  onBoolChange(key: keyof AppSettings, event: Event): void {
-    const checked = (event.target as HTMLInputElement).checked;
-    this.settings.update({ [key]: checked } as Partial<AppSettings>);
-  }
 
   /** Handle MIDI input enabled toggle */
   async onMidiEnabledChange(event: Event): Promise<void> {
@@ -68,44 +70,124 @@ export class MidiInputCardComponent {
     }
   }
 
-  /** Handle MIDI device selection change */
-  onMidiDeviceChange(event: Event): void {
-    const value = (event.target as HTMLSelectElement).value;
-    this.settings.update({ midiInputDeviceId: value });
+  /** Toggle an individual mapping on/off */
+  onMappingEnabledChange(index: number, event: Event): void {
+    const checked = (event.target as HTMLInputElement).checked;
+    const mappings = this.settings.settings().midiInputMappings.map((m, i) =>
+      i === index ? { ...m, enabled: checked } : m
+    );
+    this.settings.update({ midiInputMappings: mappings });
     this.midiInput.reattach();
   }
 
-  /** Start MIDI learn/capture mode for the given setting key */
-  onMidiCapture(settingKey: string): void {
-    if (this.midiCapturing === settingKey) {
-      this.midiInput.cancelLearn();
-      this.midiCapturing = null;
-      return;
+  /** Open the edit modal for an existing mapping */
+  startEdit(index: number): void {
+    const m = this.settings.settings().midiInputMappings[index];
+    this.editIndex = index;
+    this.editMapping = { ...m };
+    this.showEditModal = true;
+    this.ensureDevicesEnumerated();
+  }
+
+  /** Open the edit modal for a new mapping */
+  addMapping(): void {
+    this.editIndex = -1;
+    this.editMapping = {
+      enabled: true, deviceId: '', channel: 0, source: 'rx',
+      mode: 'straightKey', value: 60, dahValue: -1, reversePaddles: false,
+      name: '', color: '',
+    };
+    this.showEditModal = true;
+    this.ensureDevicesEnumerated();
+  }
+
+  /** Ensure MIDI devices are enumerated for the edit modal dropdown */
+  private ensureDevicesEnumerated(): void {
+    if (this.midiInput.midiInputs().length === 0) {
+      this.midiInput.enumerateDevices();
     }
-    if (!this.midiInput.connected()) {
-      this.midiInput.start().then(() => this.beginCapture(settingKey));
+  }
+
+  /** Handle save from the edit modal */
+  onEditSaved(event: MidiInputEditSaveEvent): void {
+    const mappings = [...this.settings.settings().midiInputMappings];
+    if (this.editIndex >= 0) {
+      mappings[this.editIndex] = {
+        ...mappings[this.editIndex],
+        deviceId: event.deviceId,
+        channel: event.channel,
+        source: event.source,
+        mode: event.mode,
+        value: event.value,
+        dahValue: event.dahValue,
+        reversePaddles: event.reversePaddles,
+        name: event.name,
+        color: event.color,
+      };
     } else {
-      this.beginCapture(settingKey);
+      mappings.push({
+        enabled: true,
+        deviceId: event.deviceId,
+        channel: event.channel,
+        source: event.source,
+        mode: event.mode,
+        value: event.value,
+        dahValue: event.dahValue,
+        reversePaddles: event.reversePaddles,
+        name: event.name,
+        color: event.color,
+      });
     }
+    this.settings.update({ midiInputMappings: mappings });
+    this.showEditModal = false;
+    this.midiInput.reattach();
   }
 
-  /** Internal: activate MIDI learn callback */
-  private beginCapture(settingKey: string): void {
-    this.midiCapturing = settingKey;
-    this.midiInput.startLearn((note: number) => {
-      this.settings.update({ [settingKey]: note } as Partial<AppSettings>);
-      this.midiCapturing = null;
-    });
+  /** Handle cancel from the edit modal */
+  onEditCancelled(): void {
+    this.showEditModal = false;
   }
 
-  /** Clear a MIDI note assignment (set to -1 = unassigned) */
-  clearMidiNote(settingKey: string): void {
-    this.settings.update({ [settingKey]: -1 } as Partial<AppSettings>);
+  /** Handle delete from the edit modal */
+  onEditDeleted(): void {
+    if (this.editIndex >= 0) {
+      const mappings = this.settings.settings().midiInputMappings.filter((_, i) => i !== this.editIndex);
+      this.settings.update({ midiInputMappings: mappings });
+      this.midiInput.reattach();
+    }
+    this.showEditModal = false;
   }
 
-  /** Display a MIDI note number as a human-readable name */
-  midiNoteDisplay(note: number): string {
-    if (note < 0) return '(none)';
-    return `${midiNoteName(note)} (${note})`;
+  /** Display a MIDI note as human-readable name */
+  noteDisplay(note: number): string {
+    if (note < 0) return '—';
+    return `${midiNoteName(note)}(${note})`;
+  }
+
+  /** Get a short summary for a mapping row */
+  mappingSummary(m: MidiInputMapping): string {
+    const ch = m.channel === 0 ? '*' : String(m.channel);
+    if (m.mode === 'straightKey') {
+      return `${ch}/${this.noteDisplay(m.value)}`;
+    }
+    return `${ch}/${this.noteDisplay(m.value)}/${this.noteDisplay(m.dahValue)}`;
+  }
+
+  /** Get a device display name for a mapping */
+  deviceDisplay(m: MidiInputMapping): string {
+    if (!m.deviceId) return 'Any';
+    const dev = this.midiInput.midiInputs().find(d => d.id === m.deviceId);
+    return dev ? dev.name : 'Disconnected';
+  }
+
+  /** Get channel display */
+  channelDisplay(m: MidiInputMapping): string {
+    return m.channel === 0 ? 'Omni' : `Ch ${m.channel}`;
+  }
+
+  /** Get the display color for a mapping's name label */
+  nameColor(m: MidiInputMapping): string {
+    if (m.color) return m.color;
+    return m.source === 'rx' ? '#8cf' : '#fc8';
   }
 }

--- a/src/app/components/settings-modal/settings-inputs-tab/settings-inputs-tab.component.css
+++ b/src/app/components/settings-modal/settings-inputs-tab/settings-inputs-tab.component.css
@@ -1,6 +1,101 @@
 /**
  * Morse Code Studio — Settings Inputs Tab
  *
- * Component-specific styles (currently empty — all card styles are in
- * the shared settings-shared.css referenced via styleUrls).
+ * Inputs-tab-specific styles — MIDI input mapping list rows and controls.
+ * Loaded globally via angular.json (not via component styleUrls) so all
+ * card child components can use these classes without duplication.
  */
+
+/* ===== MIDI Input Mapping List ===== */
+.midi-mapping-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-top: 0.5rem;
+}
+.midi-mapping-row {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.5rem;
+  background: #1a1a28;
+  border: 1px solid #335;
+  border-radius: 4px;
+}
+.midi-mapping-row-disabled {
+  opacity: 0.5;
+}
+.midi-mapping-enable {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+.midi-mapping-name {
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 6rem;
+}
+.midi-mapping-mode {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #8af;
+  min-width: 3.2rem;
+  cursor: pointer;
+}
+.midi-mapping-value {
+  font-family: monospace;
+  font-size: 0.85rem;
+  color: #ddd;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.source-badge-sm {
+  font-size: 0.65rem;
+  padding: 0.05rem 0.3rem;
+  cursor: pointer;
+}
+.midi-mapping-reverse {
+  font-size: 0.85rem;
+  color: #aaa;
+  cursor: pointer;
+}
+.midi-mapping-spacer {
+  flex: 1;
+}
+.midi-mapping-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.95rem;
+  padding: 0.25rem 0.35rem;
+  border-radius: 3px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.midi-mapping-btn svg {
+  display: block;
+}
+.midi-mapping-btn-edit { color: #aaa; }
+.midi-mapping-btn-edit:hover { color: #fff; background: #333; }
+.midi-mapping-add-btn {
+  margin-top: 0.5rem;
+  background: #2a2a3e;
+  color: #8af;
+  border: 1px dashed #446;
+  border-radius: 4px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.midi-mapping-add-btn:hover {
+  background: #333;
+}

--- a/src/app/components/settings-modal/settings-inputs-tab/settings-inputs-tab.component.html
+++ b/src/app/components/settings-modal/settings-inputs-tab/settings-inputs-tab.component.html
@@ -1,10 +1,10 @@
 <!-- Inputs tab — 8 input source settings cards -->
 
-<app-mic-card [audioRunning]="audioRunning"></app-mic-card>
-<app-cw-detector-card [audioRunning]="audioRunning"></app-cw-detector-card>
 <app-keyboard-keyer-card></app-keyboard-keyer-card>
 <app-mouse-keyer-card></app-mouse-keyer-card>
 <app-touch-keyer-card></app-touch-keyer-card>
 <app-midi-input-card></app-midi-input-card>
 <app-serial-input-card></app-serial-input-card>
 <app-rtdb-input-card></app-rtdb-input-card>
+<app-cw-detector-card [audioRunning]="audioRunning"></app-cw-detector-card>
+<app-mic-card [audioRunning]="audioRunning"></app-mic-card>

--- a/src/app/components/settings-modal/settings-outputs-tab/audio-output-card/audio-output-card.component.html
+++ b/src/app/components/settings-modal/settings-outputs-tab/audio-output-card/audio-output-card.component.html
@@ -1,9 +1,9 @@
-<!-- Audio Output (Optocoupler) -->
+<!-- Audio Key Output (Optocoupler) -->
 <div class="settings-card" [class.disabled-card]="!settings.settings().optoEnabled">
   <div class="settings-card-header" (click)="expanded = !expanded">
     <div class="settings-card-title">
       <span class="settings-card-chevron">{{ expanded ? '&#9660;' : '&#9654;' }}</span>
-      <span class="settings-card-name">Audio Output</span>
+      <span class="settings-card-name">Audio Key Output</span>
       <span class="source-badge" [class.source-rx]="settings.settings().optoForward === 'rx'" [class.source-tx]="settings.settings().optoForward === 'tx'" [class.source-both]="settings.settings().optoForward === 'both'">{{ settings.settings().optoForward === 'rx' ? 'RX' : settings.settings().optoForward === 'tx' ? 'TX' : 'RX/TX' }}</span>
     </div>
     <label class="toggle-switch" (click)="$event.stopPropagation()">

--- a/src/app/components/settings-modal/settings-outputs-tab/midi-output-card/midi-output-card.component.html
+++ b/src/app/components/settings-modal/settings-outputs-tab/midi-output-card/midi-output-card.component.html
@@ -4,7 +4,6 @@
     <div class="settings-card-title">
       <span class="settings-card-chevron">{{ expanded ? '&#9660;' : '&#9654;' }}</span>
       <span class="settings-card-name">MIDI Output</span>
-      <span class="source-badge" [class.source-rx]="settings.settings().midiOutputForward === 'rx'" [class.source-tx]="settings.settings().midiOutputForward === 'tx'" [class.source-both]="settings.settings().midiOutputForward === 'both'">{{ settings.settings().midiOutputForward === 'rx' ? 'RX' : settings.settings().midiOutputForward === 'tx' ? 'TX' : 'RX/TX' }}</span>
     </div>
     <span class="connectivity-badge" [class.connected]="midiOutput.connected()" [class.disconnected]="!midiOutput.connected()">
       @if (midiOutput.connected()) {
@@ -22,14 +21,6 @@
   </div>
   @if (expanded) {
     <div class="settings-card-body">
-      <label>Forward:
-        <select [value]="settings.settings().midiOutputForward"
-                (change)="onSettingChange('midiOutputForward', $event)">
-          <option value="tx" [selected]="settings.settings().midiOutputForward === 'tx'">TX only &mdash; transmitted morse</option>
-          <option value="rx" [selected]="settings.settings().midiOutputForward === 'rx'">RX only &mdash; received morse</option>
-          <option value="both" [selected]="settings.settings().midiOutputForward === 'both'">Both RX and TX</option>
-        </select>
-      </label>
 
       @if (!midiOutput.supported) {
         <div class="conflict-warning">
@@ -41,27 +32,31 @@
         <div class="conflict-warning">{{ midiOutput.lastError() }}</div>
       }
 
-      <label>MIDI Device:
-        <select [value]="settings.settings().midiOutputDeviceId" (change)="onMidiOutputDeviceChange($event)">
-          <option value="">Any (first available)</option>
-          @for (dev of midiOutput.midiOutputs(); track dev.id) {
-            <option [value]="dev.id" [selected]="dev.id === settings.settings().midiOutputDeviceId">{{ dev.name }}</option>
-          }
-        </select>
-      </label>
+      <div class="midi-mapping-list">
+        @for (mapping of settings.settings().midiOutputMappings; track $index) {
+          <div class="midi-mapping-row" [class.midi-mapping-row-disabled]="!mapping.enabled">
+            <label class="midi-mapping-enable">
+              <input type="checkbox" [checked]="mapping.enabled"
+                     (change)="onMappingEnabledChange($index, $event)">
+            </label>
+            <span class="midi-mapping-mode" (click)="startEdit($index)">{{ mapping.mode === 'straightKey' ? 'Straight' : 'Paddle' }}</span>
+            <span class="midi-mapping-value" (click)="startEdit($index)">{{ mappingSummary(mapping) }}</span>
+            <span class="source-badge source-badge-sm" [class.source-rx]="mapping.forward === 'rx'" [class.source-tx]="mapping.forward === 'tx'" [class.source-both]="mapping.forward === 'both'" (click)="startEdit($index)">{{ mapping.forward === 'rx' ? 'RX' : mapping.forward === 'tx' ? 'TX' : 'RX/TX' }}</span>
+            <span class="midi-mapping-spacer"></span>
+            <button class="midi-mapping-btn midi-mapping-btn-edit" (click)="startEdit($index)" title="Edit">
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
+            </button>
+          </div>
+        }
+      </div>
+      <button class="midi-mapping-add-btn" (click)="addMapping()">+ Add Mapping</button>
 
-      <label>MIDI Channel:
-        <select [value]="settings.settings().midiOutputChannel" (change)="onSettingChange('midiOutputChannel', $event)">
-          @for (ch of midiChannels; track ch) {
-            <option [value]="ch" [selected]="ch === settings.settings().midiOutputChannel">Channel {{ ch }}</option>
-          }
-        </select>
-      </label>
-
-      <label>Velocity:
-        <input type="number" min="1" max="127" [value]="settings.settings().midiOutputVelocity"
-               (change)="onSettingChange('midiOutputVelocity', $event)">
-      </label>
+      <div class="cw-hint">
+        Characters from any input are played as morse elements (dits/dahs) at
+        Encoder WPM. <strong>Straight Key</strong> fires on every element.
+        <strong>Paddle</strong> fires dit/dah notes separately. Both
+        straight-key and element-specific notes fire simultaneously.
+      </div>
 
       <label class="checkbox-label">
         <input type="checkbox" [checked]="settings.settings().midiOutputOverrideWpm"
@@ -69,120 +64,9 @@
         Override remote WPM with local encoder WPM
       </label>
       <div class="cw-hint">
-        Characters received via Firebase RTDB carry the WPM speed that was
-        used to generate them. By default, MIDI output plays those characters
-        at the sender's original speed. Enable this option to ignore the
-        remote WPM and use your local Encoder WPM instead.
+        Firebase RTDB characters carry the sender's WPM. Enable to use your
+        local Encoder WPM instead.
       </div>
-
-      <!-- Straight Key Note -->
-      <div class="midi-output-note-row">
-        <span class="midi-output-note-label">Straight Key:</span>
-        @if (!midiOutputRawMode['midiOutputStraightKeyNote']) {
-          <select class="midi-note-select"
-                  [value]="midiOutputNoteNameIndex(settings.settings().midiOutputStraightKeyNote)"
-                  (change)="onMidiOutputNoteNameChange('midiOutputStraightKeyNote', $event)">
-            @for (name of noteNames; track $index) {
-              <option [value]="$index">{{ name }}</option>
-            }
-          </select>
-          <select class="midi-octave-select"
-                  [value]="midiOutputNoteOctave(settings.settings().midiOutputStraightKeyNote)"
-                  (change)="onMidiOutputOctaveChange('midiOutputStraightKeyNote', $event)">
-            @for (oct of octaves; track oct) {
-              <option [value]="oct">{{ oct }}</option>
-            }
-          </select>
-        } @else {
-          <input type="number" class="midi-raw-input" min="0" max="127"
-                 [value]="settings.settings().midiOutputStraightKeyNote"
-                 (change)="onMidiOutputRawNoteChange('midiOutputStraightKeyNote', $event)">
-        }
-        <button class="midi-mode-toggle" (click)="toggleMidiOutputRawMode('midiOutputStraightKeyNote')"
-                title="Toggle between note/octave picker and raw MIDI value">
-          {{ midiOutputRawMode['midiOutputStraightKeyNote'] ? '&#9835;' : '#' }}
-        </button>
-        <span class="midi-note-preview">{{ midiOutputNoteDisplay(settings.settings().midiOutputStraightKeyNote) }}</span>
-      </div>
-
-      <!-- Dit Paddle Note -->
-      <div class="midi-output-note-row">
-        <span class="midi-output-note-label">Dit Paddle:</span>
-        @if (!midiOutputRawMode['midiOutputDitNote']) {
-          <select class="midi-note-select"
-                  [value]="midiOutputNoteNameIndex(settings.settings().midiOutputDitNote)"
-                  (change)="onMidiOutputNoteNameChange('midiOutputDitNote', $event)">
-            @for (name of noteNames; track $index) {
-              <option [value]="$index">{{ name }}</option>
-            }
-          </select>
-          <select class="midi-octave-select"
-                  [value]="midiOutputNoteOctave(settings.settings().midiOutputDitNote)"
-                  (change)="onMidiOutputOctaveChange('midiOutputDitNote', $event)">
-            @for (oct of octaves; track oct) {
-              <option [value]="oct">{{ oct }}</option>
-            }
-          </select>
-        } @else {
-          <input type="number" class="midi-raw-input" min="0" max="127"
-                 [value]="settings.settings().midiOutputDitNote"
-                 (change)="onMidiOutputRawNoteChange('midiOutputDitNote', $event)">
-        }
-        <button class="midi-mode-toggle" (click)="toggleMidiOutputRawMode('midiOutputDitNote')"
-                title="Toggle between note/octave picker and raw MIDI value">
-          {{ midiOutputRawMode['midiOutputDitNote'] ? '&#9835;' : '#' }}
-        </button>
-        <span class="midi-note-preview">{{ midiOutputNoteDisplay(settings.settings().midiOutputDitNote) }}</span>
-      </div>
-
-      <!-- Dah Paddle Note -->
-      <div class="midi-output-note-row">
-        <span class="midi-output-note-label">Dah Paddle:</span>
-        @if (!midiOutputRawMode['midiOutputDahNote']) {
-          <select class="midi-note-select"
-                  [value]="midiOutputNoteNameIndex(settings.settings().midiOutputDahNote)"
-                  (change)="onMidiOutputNoteNameChange('midiOutputDahNote', $event)">
-            @for (name of noteNames; track $index) {
-              <option [value]="$index">{{ name }}</option>
-            }
-          </select>
-          <select class="midi-octave-select"
-                  [value]="midiOutputNoteOctave(settings.settings().midiOutputDahNote)"
-                  (change)="onMidiOutputOctaveChange('midiOutputDahNote', $event)">
-            @for (oct of octaves; track oct) {
-              <option [value]="oct">{{ oct }}</option>
-            }
-          </select>
-        } @else {
-          <input type="number" class="midi-raw-input" min="0" max="127"
-                 [value]="settings.settings().midiOutputDahNote"
-                 (change)="onMidiOutputRawNoteChange('midiOutputDahNote', $event)">
-        }
-        <button class="midi-mode-toggle" (click)="toggleMidiOutputRawMode('midiOutputDahNote')"
-                title="Toggle between note/octave picker and raw MIDI value">
-          {{ midiOutputRawMode['midiOutputDahNote'] ? '&#9835;' : '#' }}
-        </button>
-        <span class="midi-note-preview">{{ midiOutputNoteDisplay(settings.settings().midiOutputDahNote) }}</span>
-      </div>
-
-      <div class="cw-hint">
-        Decoded characters from any input are played back as individual
-        morse elements (dits and dahs) at Encoder WPM speed. Ideal for an
-        Arduino Pro Micro with MIDIUSB library &mdash; the Arduino's digital
-        pins can be wired to keying circuits.<br><br>
-        <strong>Straight Key</strong> note fires during every element (dit or dah).
-        <strong>Dit Paddle</strong> fires during dits only.
-        <strong>Dah Paddle</strong> fires during dahs only.
-        During each element, both the Straight Key and the element-specific
-        note fire simultaneously.<br><br>
-        Use the <strong>&#9835;</strong> button to switch between note/octave picker
-        and raw 0&ndash;127 value entry. Velocity defaults to 127 (maximum).
-      </div>
-
-      <button [disabled]="!midiOutput.connected()"
-              (click)="midiOutput.test()" class="test-btn">
-        Test Output (1s)
-      </button>
 
       <div class="serial-port-row">
         @if (midiOutput.connected()) {
@@ -194,3 +78,16 @@
     </div>
   }
 </div>
+
+<!-- MIDI output edit modal (hosted here because it's triggered from this card) -->
+@if (showEditModal) {
+  <app-midi-output-edit-modal
+    [mapping]="editMapping"
+    [editIndex]="editIndex"
+    [midiDevices]="midiOutput.midiOutputs()"
+    [allMappings]="settings.settings().midiOutputMappings"
+    (saved)="onEditSaved($event)"
+    (cancelled)="onEditCancelled()"
+    (deleted)="onEditDeleted()">
+  </app-midi-output-edit-modal>
+}

--- a/src/app/components/settings-modal/settings-outputs-tab/midi-output-card/midi-output-card.component.ts
+++ b/src/app/components/settings-modal/settings-outputs-tab/midi-output-card/midi-output-card.component.ts
@@ -4,20 +4,22 @@
 
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { SettingsService, AppSettings } from '../../../../services/settings.service';
+import { SettingsService, AppSettings, MidiOutputMapping } from '../../../../services/settings.service';
 import { MidiOutputService, midiOutputNoteName } from '../../../../services/midi-output.service';
+import { MidiOutputEditModalComponent, MidiOutputEditSaveEvent } from '../../../midi-output-edit-modal/midi-output-edit-modal.component';
 
 /**
  * Settings card — MIDI Output (key events as MIDI note-on/off).
  *
- * Sends decoded morse elements as MIDI notes to an external device (e.g.
- * Arduino Pro Micro). Includes device/channel selection, velocity,
- * note assignment with picker/raw toggle, and WPM override option.
+ * Displays a table of MIDI output mappings (straight key / paddle),
+ * with add/edit/delete support via the MIDI output edit modal.
+ * Each mapping has its own device, channel, mode, and note assignments.
+ * Global settings (forward mode, override WPM) are at the card level.
  */
 @Component({
   selector: 'app-midi-output-card',
   standalone: true,
-  imports: [FormsModule],
+  imports: [FormsModule, MidiOutputEditModalComponent],
   templateUrl: './midi-output-card.component.html',
   styles: [':host { display: contents; }'],
 })
@@ -25,29 +27,22 @@ export class MidiOutputCardComponent {
   /** Whether this card's body is expanded */
   expanded = false;
 
-  /** MIDI channel numbers 1–16 for the channel select dropdown */
-  readonly midiChannels = Array.from({ length: 16 }, (_, i) => i + 1);
-  /** Note names for the MIDI output note picker dropdowns */
-  readonly noteNames = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
-  /** Octave range for MIDI output picker (-1 to 9) */
-  readonly octaves = [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-  /** Whether to show the raw 0–127 input for each MIDI output note (vs note/octave picker) */
-  midiOutputRawMode: Record<string, boolean> = {};
+  /** Index of the mapping currently being edited, or -1 for new */
+  editIndex = -1;
+
+  /** Scratch copy of the mapping passed to the edit modal */
+  editMapping: MidiOutputMapping = {
+    enabled: true, deviceId: '', channel: 1,
+    forward: 'tx', mode: 'straightKey', value: 80, dahValue: -1,
+  };
+
+  /** Whether the edit modal is visible */
+  showEditModal = false;
 
   constructor(
     public settings: SettingsService,
     public midiOutput: MidiOutputService,
   ) {}
-
-  /** Handle a string or numeric setting change */
-  onSettingChange(key: keyof AppSettings, event: Event): void {
-    const el = event.target as HTMLInputElement;
-    let value: string | number = el.value;
-    if (el.type === 'number' || el.type === 'range') {
-      value = parseFloat(el.value);
-    }
-    this.settings.update({ [key]: value } as Partial<AppSettings>);
-  }
 
   /** Handle a boolean setting change from a checkbox */
   onBoolChange(key: keyof AppSettings, event: Event): void {
@@ -70,61 +65,105 @@ export class MidiOutputCardComponent {
     }
   }
 
-  /** Handle MIDI output device selection change */
-  onMidiOutputDeviceChange(event: Event): void {
-    const value = (event.target as HTMLSelectElement).value;
-    this.settings.update({ midiOutputDeviceId: value });
+  /** Toggle an individual mapping on/off */
+  onMappingEnabledChange(index: number, event: Event): void {
+    const checked = (event.target as HTMLInputElement).checked;
+    const mappings = this.settings.settings().midiOutputMappings.map((m, i) =>
+      i === index ? { ...m, enabled: checked } : m
+    );
+    this.settings.update({ midiOutputMappings: mappings });
     this.midiOutput.reattach();
   }
 
-  /** Display a MIDI output note number as a human-readable name (e.g. "C4 (60)") */
-  midiOutputNoteDisplay(note: number): string {
-    if (note < 0) return '(none)';
-    return `${midiOutputNoteName(note)} (${note})`;
+  /** Open the edit modal for an existing mapping */
+  startEdit(index: number): void {
+    const m = this.settings.settings().midiOutputMappings[index];
+    this.editIndex = index;
+    this.editMapping = { ...m };
+    this.showEditModal = true;
+    this.ensureDevicesEnumerated();
   }
 
-  /** Get note name index (0–11) from a MIDI note number */
-  midiOutputNoteNameIndex(note: number): number {
-    return note >= 0 ? note % 12 : 0;
+  /** Open the edit modal for a new mapping */
+  addMapping(): void {
+    this.editIndex = -1;
+    this.editMapping = {
+      enabled: true, deviceId: '', channel: 1,
+      forward: 'tx', mode: 'straightKey', value: 80, dahValue: -1,
+    };
+    this.showEditModal = true;
+    this.ensureDevicesEnumerated();
   }
 
-  /** Get octave from a MIDI note number */
-  midiOutputNoteOctave(note: number): number {
-    return note >= 0 ? Math.floor(note / 12) - 1 : 4;
-  }
-
-  /** Update a MIDI output note from the note name picker dropdown */
-  onMidiOutputNoteNameChange(settingKey: string, event: Event): void {
-    const nameIdx = parseInt((event.target as HTMLSelectElement).value, 10);
-    const current = (this.settings.settings() as any)[settingKey] as number;
-    const octave = current >= 0 ? Math.floor(current / 12) - 1 : 4;
-    const note = (octave + 1) * 12 + nameIdx;
-    if (note >= 0 && note <= 127) {
-      this.settings.update({ [settingKey]: note } as Partial<AppSettings>);
+  /** Handle save from the edit modal */
+  onEditSaved(event: MidiOutputEditSaveEvent): void {
+    const mappings = [...this.settings.settings().midiOutputMappings];
+    if (this.editIndex >= 0) {
+      mappings[this.editIndex] = {
+        ...mappings[this.editIndex],
+        deviceId: event.deviceId,
+        channel: event.channel,
+        forward: event.forward,
+        mode: event.mode,
+        value: event.value,
+        dahValue: event.dahValue,
+      };
+    } else {
+      mappings.push({
+        enabled: true,
+        deviceId: event.deviceId,
+        channel: event.channel,
+        forward: event.forward,
+        mode: event.mode,
+        value: event.value,
+        dahValue: event.dahValue,
+      });
     }
+    this.settings.update({ midiOutputMappings: mappings });
+    this.showEditModal = false;
+    this.midiOutput.reattach();
   }
 
-  /** Update a MIDI output note from the octave picker dropdown */
-  onMidiOutputOctaveChange(settingKey: string, event: Event): void {
-    const octave = parseInt((event.target as HTMLSelectElement).value, 10);
-    const current = (this.settings.settings() as any)[settingKey] as number;
-    const nameIdx = current >= 0 ? current % 12 : 0;
-    const note = (octave + 1) * 12 + nameIdx;
-    if (note >= 0 && note <= 127) {
-      this.settings.update({ [settingKey]: note } as Partial<AppSettings>);
+  /** Handle cancel from the edit modal */
+  onEditCancelled(): void {
+    this.showEditModal = false;
+  }
+
+  /** Handle delete from the edit modal */
+  onEditDeleted(): void {
+    if (this.editIndex >= 0) {
+      const mappings = this.settings.settings().midiOutputMappings.filter((_, i) => i !== this.editIndex);
+      this.settings.update({ midiOutputMappings: mappings });
+      this.midiOutput.reattach();
     }
+    this.showEditModal = false;
   }
 
-  /** Update a MIDI output note from raw 0–127 numeric input */
-  onMidiOutputRawNoteChange(settingKey: string, event: Event): void {
-    const value = parseInt((event.target as HTMLInputElement).value, 10);
-    if (!isNaN(value) && value >= 0 && value <= 127) {
-      this.settings.update({ [settingKey]: value } as Partial<AppSettings>);
+  /** Display a MIDI note as human-readable name */
+  noteDisplay(note: number): string {
+    if (note < 0) return '—';
+    return `${midiOutputNoteName(note)}(${note})`;
+  }
+
+  /** Get a short summary for a mapping row */
+  mappingSummary(m: MidiOutputMapping): string {
+    if (m.mode === 'straightKey') {
+      return `${m.channel}/${this.noteDisplay(m.value)}`;
     }
+    return `${m.channel}/${this.noteDisplay(m.value)}/${this.noteDisplay(m.dahValue)}`;
   }
 
-  /** Toggle between note/octave picker and raw MIDI value entry */
-  toggleMidiOutputRawMode(key: string): void {
-    this.midiOutputRawMode[key] = !this.midiOutputRawMode[key];
+  /** Get a device display name for a mapping */
+  deviceDisplay(m: MidiOutputMapping): string {
+    if (!m.deviceId) return 'Any';
+    const dev = this.midiOutput.midiOutputs().find(d => d.id === m.deviceId);
+    return dev ? dev.name : 'Disconnected';
+  }
+
+  /** Ensure MIDI devices are enumerated for the edit modal dropdown */
+  private ensureDevicesEnumerated(): void {
+    if (this.midiOutput.midiOutputs().length === 0) {
+      this.midiOutput.enumerateDevices();
+    }
   }
 }

--- a/src/app/components/settings-modal/settings-outputs-tab/rtdb-output-card/rtdb-output-card.component.html
+++ b/src/app/components/settings-modal/settings-outputs-tab/rtdb-output-card/rtdb-output-card.component.html
@@ -50,9 +50,9 @@
                maxlength="50">
       </label>
 
-      <label>User Name:
-        <input type="text" [value]="settings.settings().rtdbOutputUserName"
-               (input)="onTextSettingChange('rtdbOutputUserName', $event)"
+      <label>Name:
+        <input type="text" [value]="settings.settings().rtdbOutputName"
+               (input)="onTextSettingChange('rtdbOutputName', $event)"
                placeholder="e.g. 5B4AON"
                maxlength="20">
       </label>

--- a/src/app/components/settings-modal/settings-outputs-tab/rtdb-output-card/rtdb-output-card.component.ts
+++ b/src/app/components/settings-modal/settings-outputs-tab/rtdb-output-card/rtdb-output-card.component.ts
@@ -71,7 +71,7 @@ export class RtdbOutputCardComponent implements OnDestroy {
     const value = (event.target as HTMLInputElement).value;
     this.settings.update({ [key]: value } as Partial<AppSettings>);
 
-    const rtdbOutputKeys: (keyof AppSettings)[] = ['rtdbOutputChannelName', 'rtdbOutputChannelSecret', 'rtdbOutputUserName'];
+    const rtdbOutputKeys: (keyof AppSettings)[] = ['rtdbOutputChannelName', 'rtdbOutputChannelSecret', 'rtdbOutputName'];
     if (rtdbOutputKeys.includes(key) && this.settings.settings().rtdbOutputEnabled) {
       if (this.rtdbOutputDebounce) clearTimeout(this.rtdbOutputDebounce);
       this.rtdbOutputDebounce = setTimeout(() => this.rtdbService.startOutput(), 600);

--- a/src/app/components/settings-modal/settings-outputs-tab/settings-outputs-tab.component.html
+++ b/src/app/components/settings-modal/settings-outputs-tab/settings-outputs-tab.component.html
@@ -1,9 +1,9 @@
 <!-- Outputs tab — 7 output destination settings cards -->
 
-<app-audio-output-card [audioRunning]="audioRunning"></app-audio-output-card>
-<app-serial-output-card></app-serial-output-card>
-<app-winkeyer-card></app-winkeyer-card>
-<app-rtdb-output-card></app-rtdb-output-card>
-<app-midi-output-card></app-midi-output-card>
 <app-sidetone-card [audioRunning]="audioRunning"></app-sidetone-card>
 <app-vibration-card></app-vibration-card>
+<app-midi-output-card></app-midi-output-card>
+<app-serial-output-card></app-serial-output-card>
+<app-rtdb-output-card></app-rtdb-output-card>
+<app-winkeyer-card></app-winkeyer-card>
+<app-audio-output-card [audioRunning]="audioRunning"></app-audio-output-card>

--- a/src/app/firebase.config.ts
+++ b/src/app/firebase.config.ts
@@ -26,11 +26,11 @@
  *             "$secret": {
  *               ".read": true,
  *               ".write": true,
- *               ".validate": "newData.hasChildren(['char', 'userName', 'ts', 'wpm'])
+ *               ".validate": "newData.hasChildren(['char', 'name', 'ts', 'wpm'])
  *                             && newData.child('char').isString()
  *                             && newData.child('char').val().length <= 5
- *                             && newData.child('userName').isString()
- *                             && newData.child('userName').val().length <= 20
+ *                             && newData.child('name').isString()
+ *                             && newData.child('name').val().length <= 20
  *                             && newData.child('ts').val() === now
  *                             && newData.child('wpm').isNumber()
  *                             && newData.child('wpm').val() >= 5

--- a/src/app/services/display-buffer.service.ts
+++ b/src/app/services/display-buffer.service.ts
@@ -12,7 +12,8 @@ import { PUNCTUATION_TO_PROSIGN } from '../morse-table';
 export interface DisplayEntry {
   type: 'rx' | 'tx';
   char: string;
-  userName?: string;
+  name?: string;
+  color?: string;
 }
 
 /**
@@ -21,7 +22,8 @@ export interface DisplayEntry {
 export interface DisplayLine {
   type: 'rx' | 'tx';
   text: string;
-  userName?: string;
+  name?: string;
+  color?: string;
 }
 
 /**
@@ -60,9 +62,9 @@ export class DisplayBuffer {
   }
 
   /** Append one or more characters. */
-  push(type: 'rx' | 'tx', text: string, userName?: string): void {
+  push(type: 'rx' | 'tx', text: string, name?: string, color?: string): void {
     for (const char of text) {
-      this.entries.push({ type, char, userName });
+      this.entries.push({ type, char, name, color });
     }
     this.trim();
     this.rebuild();
@@ -89,24 +91,24 @@ export class DisplayBuffer {
    *  - clearLine:      removes entries back to the last newline (or start)
    *  - clearScreen:    clears all entries
    */
-  applyProsignAction(action: ProsignAction, type: 'rx' | 'tx', userName?: string, prosignLabel?: string): void {
+  applyProsignAction(action: ProsignAction, type: 'rx' | 'tx', name?: string, prosignLabel?: string, color?: string): void {
     switch (action) {
       case 'newLine':
         if (prosignLabel) {
           for (const ch of prosignLabel) {
-            this.entries.push({ type, char: ch, userName });
+            this.entries.push({ type, char: ch, name, color });
           }
         }
-        this.entries.push({ type, char: '\n', userName });
+        this.entries.push({ type, char: '\n', name, color });
         break;
       case 'newParagraph':
         if (prosignLabel) {
           for (const ch of prosignLabel) {
-            this.entries.push({ type, char: ch, userName });
+            this.entries.push({ type, char: ch, name, color });
           }
         }
-        this.entries.push({ type, char: '\n', userName });
-        this.entries.push({ type, char: '\n', userName });
+        this.entries.push({ type, char: '\n', name, color });
+        this.entries.push({ type, char: '\n', name, color });
         break;
       case 'clearLastWord': {
         // Remove entries back to the most recent space or newline (including trailing space)
@@ -158,20 +160,23 @@ export class DisplayBuffer {
     const lines: DisplayLine[] = [];
     let flat = '';
     let lastType: 'rx' | 'tx' | null = null;
+    let lastName: string | undefined = undefined;
 
     for (const entry of this.entries) {
-      // Insert newline when source type changes (conversation-style)
-      if (this.conversationNewlines && lastType !== null && entry.type !== lastType
+      // Insert newline when source type or name changes (conversation-style)
+      if (this.conversationNewlines && lastType !== null
+          && (entry.type !== lastType || entry.name !== lastName)
           && entry.char !== '\n' && !flat.endsWith('\n')) {
         flat += '\n';
       }
       lastType = entry.type;
+      lastName = entry.name;
       flat += entry.char;
       const last = lines.length > 0 ? lines[lines.length - 1] : null;
-      if (last && last.type === entry.type && last.userName === entry.userName) {
+      if (last && last.type === entry.type && last.name === entry.name && last.color === entry.color) {
         last.text += entry.char;
       } else {
-        lines.push({ type: entry.type, text: entry.char, userName: entry.userName });
+        lines.push({ type: entry.type, text: entry.char, name: entry.name, color: entry.color });
       }
     }
 
@@ -214,7 +219,7 @@ export class DisplayBufferService {
    * If the character is a prosign with an enabled action, the action
    * is applied to all buffers instead of the raw text.
    */
-  pushDecoded(type: 'rx' | 'tx', char: string, userName?: string): void {
+  pushDecoded(type: 'rx' | 'tx', char: string, name?: string, color?: string): void {
     // Suppress the word-gap space that follows a prosign action
     if (this.suppressNextSpace && char === ' ') {
       this.suppressNextSpace = false;
@@ -225,15 +230,15 @@ export class DisplayBufferService {
     const resolved = this.resolveProsignAction(char);
     if (resolved) {
       const label = resolved.prosignKey;
-      this.mainOutput.applyProsignAction(resolved.action, type, userName, label);
-      this.fullscreenDecoder.applyProsignAction(resolved.action, type, userName, label);
-      this.fullscreenEncoder.applyProsignAction(resolved.action, type, userName, label);
+      this.mainOutput.applyProsignAction(resolved.action, type, name, label, color);
+      this.fullscreenDecoder.applyProsignAction(resolved.action, type, name, label, color);
+      this.fullscreenEncoder.applyProsignAction(resolved.action, type, name, label, color);
       this.suppressNextSpace = true;
     } else {
       this.suppressNextSpace = false;
-      this.mainOutput.push(type, char, userName);
-      this.fullscreenDecoder.push(type, char, userName);
-      this.fullscreenEncoder.push(type, char, userName);
+      this.mainOutput.push(type, char, name, color);
+      this.fullscreenDecoder.push(type, char, name, color);
+      this.fullscreenEncoder.push(type, char, name, color);
     }
   }
 
@@ -243,7 +248,7 @@ export class DisplayBufferService {
    * If the character is a prosign with an enabled action, the action
    * is applied to all buffers instead of the raw text.
    */
-  pushSent(char: string, userName?: string): void {
+  pushSent(char: string, name?: string): void {
     // Suppress the word-gap space that follows a prosign action
     if (this.suppressNextSpace && char === ' ') {
       this.suppressNextSpace = false;
@@ -254,15 +259,15 @@ export class DisplayBufferService {
     const resolved = this.resolveProsignAction(char);
     if (resolved) {
       const label = resolved.prosignKey;
-      this.mainOutput.applyProsignAction(resolved.action, 'tx', userName, label);
-      this.fullscreenDecoder.applyProsignAction(resolved.action, 'tx', userName, label);
-      this.fullscreenEncoder.applyProsignAction(resolved.action, 'tx', userName, label);
+      this.mainOutput.applyProsignAction(resolved.action, 'tx', name, label);
+      this.fullscreenDecoder.applyProsignAction(resolved.action, 'tx', name, label);
+      this.fullscreenEncoder.applyProsignAction(resolved.action, 'tx', name, label);
       this.suppressNextSpace = true;
     } else {
       this.suppressNextSpace = false;
-      this.mainOutput.push('tx', char, userName);
-      this.fullscreenDecoder.push('tx', char, userName);
-      this.fullscreenEncoder.push('tx', char, userName);
+      this.mainOutput.push('tx', char, name);
+      this.fullscreenDecoder.push('tx', char, name);
+      this.fullscreenEncoder.push('tx', char, name);
     }
   }
 

--- a/src/app/services/firebase-rtdb.service.ts
+++ b/src/app/services/firebase-rtdb.service.ts
@@ -33,7 +33,7 @@ interface RtdbLetterEntry {
   /** The morse character (single letter/digit/punctuation) */
   char: string;
   /** User name (callsign) of the sender */
-  userName: string;
+  name: string;
   /** Server timestamp (ms since epoch) */
   ts: object | number;
   /** WPM speed used to generate this character (2-digit number) */
@@ -81,7 +81,7 @@ export class FirebaseRtdbService implements OnDestroy {
   readonly connectionWarning = signal<string | null>(null);
 
   /** Emits received characters from the subscribed input channel */
-  readonly incomingChar$ = new Subject<{ char: string; source: 'rx' | 'tx'; userName: string; wpm: number }>();
+  readonly incomingChar$ = new Subject<{ char: string; source: 'rx' | 'tx'; name: string; wpm: number }>();
 
   /** Whether we are actively listening to an input channel */
   readonly inputListening = signal(false);
@@ -341,10 +341,10 @@ export class FirebaseRtdbService implements OnDestroy {
           }
         }
 
-        // Skip our own echoes: if the incoming userName matches our output
-        // userName, this is a character we wrote — don't feed it back.
-        const ourName = this.settings.settings().rtdbOutputUserName.trim();
-        if (ourName && data.userName === ourName) return;
+        // Skip our own echoes: if the incoming name matches our output
+        // name, this is a character we wrote — don't feed it back.
+        const ourName = this.settings.settings().rtdbOutputName.trim();
+        if (ourName && data.name === ourName) return;
 
         this.lastInputChar = data.char;
         this.lastInputTs = ts;
@@ -354,7 +354,7 @@ export class FirebaseRtdbService implements OnDestroy {
         const wpm = (typeof data.wpm === 'number' && data.wpm >= 5 && data.wpm <= 60)
           ? data.wpm
           : this.settings.settings().encoderWpm;
-        this.incomingChar$.next({ char: data.char, source, userName: data.userName || '', wpm });
+        this.incomingChar$.next({ char: data.char, source, name: data.name || '', wpm });
       });
     }, (err) => {
       this.zone.run(() => {
@@ -540,7 +540,7 @@ export class FirebaseRtdbService implements OnDestroy {
 
     const channelName = s.rtdbOutputChannelName.trim();
     const channelSecret = s.rtdbOutputChannelSecret.trim();
-    const userName = s.rtdbOutputUserName.trim();
+    const name = s.rtdbOutputName.trim();
 
     if (!channelName || !channelSecret) return;
 
@@ -550,7 +550,7 @@ export class FirebaseRtdbService implements OnDestroy {
     try {
       await set(entryRef, {
         char,
-        userName: userName || 'Anonymous',
+        name: name || 'Anonymous',
         ts: serverTimestamp(),
         wpm: wpm ?? s.encoderWpm,
       });

--- a/src/app/services/midi-input.service.ts
+++ b/src/app/services/midi-input.service.ts
@@ -4,7 +4,7 @@
 
 import { Injectable, OnDestroy, NgZone, signal } from '@angular/core';
 import { Subject } from 'rxjs';
-import { SettingsService, PaddleMode } from './settings.service';
+import { SettingsService, PaddleMode, DecoderSource } from './settings.service';
 import { MorseDecoderService } from './morse-decoder.service';
 import { MidiOutputService } from './midi-output.service';
 import { timingsFromWpm } from '../morse-table';
@@ -25,6 +25,16 @@ export function midiNoteName(note: number): string {
   if (note < 0 || note > 127) return '—';
   const octave = Math.floor(note / 12) - 1;
   return `${NOTE_NAMES[note % 12]}${octave}`;
+}
+
+/**
+ * Data captured during MIDI learn/capture mode.
+ */
+export interface MidiLearnResult {
+  note: number;
+  channel: number;
+  deviceId: string;
+  deviceName: string;
 }
 
 /**
@@ -69,7 +79,7 @@ export class MidiInputService implements OnDestroy {
   readonly lastError = signal('');
 
   /** Emits captured note during learn mode */
-  readonly learnedNote$ = new Subject<{ note: number; channel: number; deviceId: string; deviceName: string }>();
+  readonly learnedNote$ = new Subject<MidiLearnResult>();
 
   private midiAccess: MIDIAccess | null = null;
   private started = false;
@@ -78,10 +88,10 @@ export class MidiInputService implements OnDestroy {
   private startingPromise: Promise<void> | null = null;
 
   /** Learn mode: when set, the next note-on is captured instead of acted on */
-  private learnCallback: ((note: number) => void) | null = null;
+  private learnCallback: ((result: MidiLearnResult) => void) | null = null;
 
   /** Track which notes are currently held (to release on stop) */
-  private activeNotes = new Map<number, 'straightKey' | 'dit' | 'dah'>();
+  private activeNotes = new Map<number, { action: 'straightKey' | 'dit' | 'dah'; source: DecoderSource; name: string; color: string }>();
 
   /**
    * Keep-alive timer — periodically re-attaches MIDI listeners and verifies
@@ -114,6 +124,8 @@ export class MidiInputService implements OnDestroy {
   private midiElementPlaying = false;
   private midiKeyerRunning = false;
   private midiPaddleSource: 'rx' | 'tx' = 'rx';
+  private midiPaddleName = '';
+  private midiPaddleColor = '';
 
   constructor(
     private settings: SettingsService,
@@ -220,9 +232,9 @@ export class MidiInputService implements OnDestroy {
   /**
    * Enter learn mode: the next MIDI note-on will be captured and returned
    * via the callback instead of being processed as a keyer input.
-   * Used by the settings UI for the "capture" buttons.
+   * Used by the settings UI for the "capture" / auto-detect buttons.
    */
-  startLearn(callback: (note: number) => void): void {
+  startLearn(callback: (result: MidiLearnResult) => void): void {
     this.learnCallback = callback;
   }
 
@@ -240,6 +252,32 @@ export class MidiInputService implements OnDestroy {
   reattach(): void {
     if (this.started) {
       this.attachListeners();
+    }
+  }
+
+  /**
+   * Enumerate available MIDI input devices without starting the full
+   * listener pipeline. Used by the settings UI to populate device
+   * dropdowns even when MIDI input is disabled.
+   */
+  async enumerateDevices(): Promise<void> {
+    if (!this.supported) return;
+    // If already started, devices are already populated
+    if (this.started && this.midiAccess) {
+      this.refreshInputs();
+      return;
+    }
+    try {
+      const access = await (navigator as any).requestMIDIAccess({ sysex: false });
+      const inputs: { id: string; name: string }[] = [];
+      for (const input of access.inputs.values()) {
+        if (input.state === 'connected') {
+          inputs.push({ id: input.id, name: input.name || `MIDI Input ${input.id}` });
+        }
+      }
+      this.zone.run(() => this.midiInputs.set(inputs));
+    } catch {
+      // Silently ignore — the dropdown will just be empty
     }
   }
 
@@ -287,7 +325,9 @@ export class MidiInputService implements OnDestroy {
   }
 
   /**
-   * Attach onmidimessage to all connected inputs (or just the configured device).
+   * Attach onmidimessage to all connected inputs that are referenced
+   * by at least one enabled mapping (or all inputs if any mapping uses
+   * 'any' device).
    *
    * Explicitly opens each port before assigning the message handler.
    * Per the Web MIDI spec, simply assigning `onmidimessage` should auto-open
@@ -298,11 +338,13 @@ export class MidiInputService implements OnDestroy {
    */
   private attachListeners(): void {
     if (!this.midiAccess) return;
-    const configuredId = this.settings.settings().midiInputDeviceId;
+    const mappings = this.settings.settings().midiInputMappings.filter(m => m.enabled);
+    const listenAll = mappings.some(m => !m.deviceId);
+    const deviceIds = new Set(mappings.map(m => m.deviceId).filter(Boolean));
 
     for (const input of this.midiAccess.inputs.values()) {
-      // Skip disconnected devices and devices that don't match the configured ID
-      if (input.state !== 'connected' || (configuredId && input.id !== configuredId)) {
+      // Skip disconnected devices and devices that don't match any mapping
+      if (input.state !== 'connected' || (!listenAll && !deviceIds.has(input.id))) {
         input.onmidimessage = null;
         continue;
       }
@@ -338,19 +380,20 @@ export class MidiInputService implements OnDestroy {
 
     if (!isNoteOn && !isNoteOff) return;
 
-    // Channel filter: 0 = omni (accept all), 1-16 = specific
-    const channelFilter = this.settings.settings().midiInputChannel;
-    if (channelFilter > 0 && channel !== channelFilter) return;
-
     // Learn mode: capture the note and return
     if (isNoteOn && this.learnCallback) {
       const cb = this.learnCallback;
       this.learnCallback = null;
+      const target = msg.target as MIDIInput | null;
+      const result: MidiLearnResult = {
+        note,
+        channel,
+        deviceId: target?.id || '',
+        deviceName: target?.name || 'Unknown',
+      };
       this.zone.run(() => {
-        cb(note);
-        // Also emit for the UI
-        const deviceName = this.getDeviceName(msg);
-        this.learnedNote$.next({ note, channel, deviceId: '', deviceName });
+        cb(result);
+        this.learnedNote$.next(result);
       });
       return;
     }
@@ -382,53 +425,68 @@ export class MidiInputService implements OnDestroy {
     // ======================================================================
     if (isNoteOn && this.midiOutput.isSending()) return;
 
-    const s = this.settings.settings();
-    const straightSource = s.midiStraightKeySource;
-    const paddleSource = s.midiPaddleSource;
-    const reverse = s.midiReversePaddles;
-
-    // Straight key and paddle inputs bypass KeyerService completely.
-    // MIDI input talks to the decoder directly (for straight key) or
-    // through its own independent iambic keyer (for paddles).  This
-    // ensures zero shared state with the keyboard/mouse/touch keyer.
-    if (isNoteOn) {
-      if (note === s.midiStraightKeyNote) {
-        this.activeNotes.set(note, 'straightKey');
-        this.zone.run(() => {
-          this.decoder.onKeyDown('midiStraightKey', straightSource, { fromMidi: true });
-        });
-      } else if (note === s.midiDitNote) {
-        this.activeNotes.set(note, reverse ? 'dah' : 'dit');
-        if (reverse) {
-          this.midiDahPaddleInput(true, paddleSource);
-        } else {
-          this.midiDitPaddleInput(true, paddleSource);
-        }
-      } else if (note === s.midiDahNote) {
-        this.activeNotes.set(note, reverse ? 'dit' : 'dah');
-        if (reverse) {
-          this.midiDitPaddleInput(true, paddleSource);
-        } else {
-          this.midiDahPaddleInput(true, paddleSource);
-        }
-      }
-    } else if (isNoteOff) {
-      const action = this.activeNotes.get(note);
-      if (!action) return;
+    // Note-off: use stored action state
+    if (isNoteOff) {
+      const active = this.activeNotes.get(note);
+      if (!active) return;
       this.activeNotes.delete(note);
-
-      switch (action) {
+      switch (active.action) {
         case 'straightKey':
           this.zone.run(() => {
-            this.decoder.onKeyUp('midiStraightKey', straightSource, { fromMidi: true });
+            this.decoder.onKeyUp('midiStraightKey', active.source, {
+              fromMidi: true, name: active.name, color: active.color,
+            });
           });
           break;
         case 'dit':
-          this.midiDitPaddleInput(false, paddleSource);
+          this.midiDitPaddleInput(false, active.source);
           break;
         case 'dah':
-          this.midiDahPaddleInput(false, paddleSource);
+          this.midiDahPaddleInput(false, active.source);
           break;
+      }
+      return;
+    }
+
+    // Note-on: find matching mapping
+    const deviceId = (msg.target as MIDIInput | null)?.id || '';
+    const mappings = this.settings.settings().midiInputMappings;
+
+    for (const mapping of mappings) {
+      if (!mapping.enabled) continue;
+      // Device filter
+      if (mapping.deviceId && mapping.deviceId !== deviceId) continue;
+      // Channel filter
+      if (mapping.channel > 0 && mapping.channel !== channel) continue;
+
+      if (mapping.mode === 'straightKey' && note === mapping.value) {
+        this.activeNotes.set(note, { action: 'straightKey', source: mapping.source, name: mapping.name || '', color: mapping.color || '' });
+        this.zone.run(() => {
+          this.decoder.onKeyDown('midiStraightKey', mapping.source, {
+            fromMidi: true, name: mapping.name || undefined, color: mapping.color || undefined,
+          });
+        });
+        return;
+      }
+
+      if (mapping.mode === 'paddle') {
+        const reverse = mapping.reversePaddles;
+        const ditValue = reverse ? mapping.dahValue : mapping.value;
+        const dahValue = reverse ? mapping.value : mapping.dahValue;
+        if (note === ditValue) {
+          this.activeNotes.set(note, { action: 'dit', source: mapping.source, name: mapping.name || '', color: mapping.color || '' });
+          this.midiPaddleName = mapping.name || '';
+          this.midiPaddleColor = mapping.color || '';
+          this.midiDitPaddleInput(true, mapping.source);
+          return;
+        }
+        if (note === dahValue) {
+          this.activeNotes.set(note, { action: 'dah', source: mapping.source, name: mapping.name || '', color: mapping.color || '' });
+          this.midiPaddleName = mapping.name || '';
+          this.midiPaddleColor = mapping.color || '';
+          this.midiDahPaddleInput(true, mapping.source);
+          return;
+        }
       }
     }
   }
@@ -457,21 +515,18 @@ export class MidiInputService implements OnDestroy {
 
   /** Release any currently active notes (called on stop) */
   private releaseAll(): void {
-    const s = this.settings.settings();
-    const straightSource = s.midiStraightKeySource;
-    const paddleSource = s.midiPaddleSource;
-    for (const [, action] of this.activeNotes) {
-      switch (action) {
+    for (const [, active] of this.activeNotes) {
+      switch (active.action) {
         case 'straightKey':
           this.zone.run(() => {
-            this.decoder.onKeyUp('midiStraightKey', straightSource, { fromMidi: true });
+            this.decoder.onKeyUp('midiStraightKey', active.source, { fromMidi: true });
           });
           break;
         case 'dit':
-          this.midiDitPaddleInput(false, paddleSource);
+          this.midiDitPaddleInput(false, active.source);
           break;
         case 'dah':
-          this.midiDahPaddleInput(false, paddleSource);
+          this.midiDahPaddleInput(false, active.source);
           break;
       }
     }
@@ -526,6 +581,8 @@ export class MidiInputService implements OnDestroy {
       this.zone.run(() => {
         this.decoder.onKeyUp('midiPaddle', this.midiPaddleSource, {
           perfectTiming: true, fromMidi: true,
+          name: this.midiPaddleName || undefined,
+          color: this.midiPaddleColor || undefined,
         });
       });
     }
@@ -558,6 +615,8 @@ export class MidiInputService implements OnDestroy {
     this.zone.run(() => {
       this.decoder.onKeyDown('midiPaddle', this.midiPaddleSource, {
         perfectTiming: true, fromMidi: true,
+        name: this.midiPaddleName || undefined,
+        color: this.midiPaddleColor || undefined,
       });
     });
 
@@ -566,6 +625,8 @@ export class MidiInputService implements OnDestroy {
       this.zone.run(() => {
         this.decoder.onKeyUp('midiPaddle', this.midiPaddleSource, {
           perfectTiming: true, fromMidi: true,
+          name: this.midiPaddleName || undefined,
+          color: this.midiPaddleColor || undefined,
         });
       });
       this.midiLastElement = this.midiCurrentElement;
@@ -621,12 +682,6 @@ export class MidiInputService implements OnDestroy {
     if (picked === 'dit') this.midiDitMemory = false;
     else if (picked === 'dah') this.midiDahMemory = false;
     return picked;
-  }
-
-  /** Try to get the device name from a MIDI message event */
-  private getDeviceName(msg: MIDIMessageEvent): string {
-    const target = msg.target as MIDIInput | null;
-    return target?.name || 'Unknown';
   }
 
   /**

--- a/src/app/services/midi-output.service.ts
+++ b/src/app/services/midi-output.service.ts
@@ -53,10 +53,9 @@ export function noteOctave(note: number): number {
  * paddle inputs, or other CW hardware for real-time, zero-latency
  * interfacing with the application.
  *
- * Three independent output notes are supported:
- *  1. **Straight key** — note-on during each element (dit or dah), note-off between.
- *  2. **Dit paddle** — note-on during dit elements only.
- *  3. **Dah paddle** — note-on during dah elements only.
+ * Multiple output mappings are supported, each targeting a specific MIDI
+ * device, channel, note, and mode (straight key or paddle). Each enabled
+ * mapping fires independently during playback.
  *
  * Operation is character-based (like WinKeyer): decoded characters from any
  * input source are played back as individual morse elements using the encoder
@@ -75,9 +74,8 @@ export function noteOctave(note: number): number {
  * when the user enables MIDI output and stays alive across audio restarts
  * and browser refreshes (Chrome remembers the grant).
  *
- * Each output has a configurable MIDI note number (0-127) and the user can
- * choose from a note/octave picker or enter a raw value. Velocity is
- * configurable (default 127).
+ * Each output mapping has a configurable MIDI note number (0-127) and
+ * mode (straight key or paddle). Velocity is always 127.
  *
  * The service shares the same Web MIDI access obtained by MidiInputService.
  * It enumerates MIDI *output* ports and allows the user to select one.
@@ -126,14 +124,16 @@ export class MidiOutputService implements OnDestroy {
   private started = false;
   private startingPromise: Promise<void> | null = null;
 
-  /** Currently active output port */
-  private activeOutput: MIDIOutput | null = null;
-
-  /** Track which notes are currently held (to release on stop) */
-  private activeNotes = new Set<number>();
+  /**
+   * Track currently held notes for proper release.
+   * Key: "note:channel" — value: { note, channel, output } so we can
+   * send the note-off on the correct port and channel even if settings
+   * change between note-on and note-off.
+   */
+  private activeNotes = new Map<string, { note: number; channel: number; output: MIDIOutput }>();
 
   /** Character playback queue */
-  private charQueue: { char: string; source: 'rx' | 'tx'; wpm?: number }[] = [];
+  private charQueue: { char: string; source: 'rx' | 'tx'; wpm?: number; paddleOnly?: boolean }[] = [];
   private playing = false;
   private abortPlayback = false;
 
@@ -224,7 +224,7 @@ export class MidiOutputService implements OnDestroy {
 
       // Enumerate whatever is already available
       this.refreshOutputs();
-      this.resolveActiveOutput();
+      this.updateConnected();
 
       this.installKeepAlive();
     } catch (err: any) {
@@ -264,7 +264,6 @@ export class MidiOutputService implements OnDestroy {
       this.midiAccess = null;
     }
 
-    this.activeOutput = null;
     this.started = false;
     this.zone.run(() => {
       this.connected.set(false);
@@ -272,10 +271,36 @@ export class MidiOutputService implements OnDestroy {
     });
   }
 
-  /** Re-resolve the active output (e.g. after settings change) */
+  /** Re-resolve the connected state (e.g. after settings change) */
   reattach(): void {
     if (this.started) {
-      this.resolveActiveOutput();
+      this.updateConnected();
+    }
+  }
+
+  /**
+   * Enumerate available MIDI output devices without starting the full
+   * service pipeline. Used by the settings UI to populate device
+   * dropdowns even when MIDI output is disabled.
+   */
+  async enumerateDevices(): Promise<void> {
+    if (!this.supported) return;
+    // If already started, devices are already populated
+    if (this.started && this.midiAccess) {
+      this.refreshOutputs();
+      return;
+    }
+    try {
+      const access = await (navigator as any).requestMIDIAccess({ sysex: false });
+      const outputs: { id: string; name: string }[] = [];
+      for (const output of access.outputs.values()) {
+        if (output.state === 'connected') {
+          outputs.push({ id: output.id, name: output.name || `MIDI Output ${output.id}` });
+        }
+      }
+      this.zone.run(() => this.midiOutputs.set(outputs));
+    } catch {
+      // Silently ignore — the dropdown will just be empty
     }
   }
 
@@ -291,15 +316,18 @@ export class MidiOutputService implements OnDestroy {
    * Works for ALL input types: encoder text, keyer paddles, straight key,
    * audio inputs, MIDI input, and Firebase RTDB.
    *
-   * @param char   The decoded character (e.g. 'A', ' ')
-   * @param source 'rx' or 'tx' — checked against forward setting
-   * @param wpm    Optional WPM from the source (e.g. Firebase RTDB remote speed)
+   * @param char       The decoded character (e.g. 'A', ' ')
+   * @param source     'rx' or 'tx' — checked against forward setting
+   * @param wpm        Optional WPM from the source (e.g. Firebase RTDB remote speed)
+   * @param paddleOnly When true, only paddle-mode mappings fire; straight-key
+   *                   mappings are skipped (they are already keyed in real-time
+   *                   via the keyDown/keyUp path for local keyer inputs).
    */
-  forwardDecodedChar(char: string, source: 'rx' | 'tx', wpm?: number): void {
-    if (!this.canOutput(source)) return;
+  forwardDecodedChar(char: string, source: 'rx' | 'tx', wpm?: number, paddleOnly = false): void {
+    if (!this.isActive()) return;
     // During break-in the remote party has priority — drop outgoing chars.
     if (this.breakInActive) return;
-    this.charQueue.push({ char, source, wpm });
+    this.charQueue.push({ char, source, wpm, paddleOnly });
     // If we're sleeping through a word gap and a real character arrives,
     // cut the sleep short so the new character plays immediately.
     if (char !== ' ' && this.spaceSleepResolve) {
@@ -318,7 +346,7 @@ export class MidiOutputService implements OnDestroy {
     try {
       while (this.charQueue.length > 0 && !this.abortPlayback) {
         const entry = this.charQueue.shift()!;
-        await this.playCharElements(entry.char, entry.wpm);
+        await this.playCharElements(entry.char, entry.source, entry.wpm, entry.paddleOnly);
       }
     } finally {
       this.playing = false;
@@ -332,19 +360,14 @@ export class MidiOutputService implements OnDestroy {
    * Uses the provided remote WPM if available and the override setting is off;
    * otherwise falls back to the local encoder WPM.
    */
-  private async playCharElements(char: string, wpm?: number): Promise<void> {
+  private async playCharElements(char: string, source: 'rx' | 'tx', wpm?: number, paddleOnly = false): Promise<void> {
     const s0 = this.settings.settings();
     const effectiveWpm = (wpm && !s0.midiOutputOverrideWpm) ? wpm : s0.encoderWpm;
     const timings = timingsFromWpm(effectiveWpm);
     const s = this.settings.settings();
-    const channel = s.midiOutputChannel;
-    const velocity = s.midiOutputVelocity;
+    const velocity = 127;
 
     if (char === ' ') {
-      // Word space = 7 dit units; 3 already elapsed as inter-char.
-      // Use an interruptible sleep so that if a new character arrives
-      // while we're waiting, the gap is cut short and playback resumes
-      // immediately — eliminating the perceived input delay.
       await this.interruptibleSleepMs(timings.interWord - timings.interChar);
       return;
     }
@@ -352,24 +375,50 @@ export class MidiOutputService implements OnDestroy {
     const morse = MORSE_TABLE[char];
     if (!morse) return;
 
+    // Collect enabled mappings whose forward filter matches the source.
+    // When paddleOnly is set, skip straight-key mappings (they are already
+    // keyed in real-time via keyDown/keyUp for local keyer inputs).
+    const enabledMappings = s.midiOutputMappings.filter(m =>
+      m.enabled && (m.forward === 'both' || m.forward === source)
+      && (!paddleOnly || m.mode === 'paddle')
+    );
+
     for (let i = 0; i < morse.length; i++) {
       if (this.abortPlayback) return;
 
       const element = morse[i];
       const duration = element === '.' ? timings.dit : timings.dah;
 
-      // Build note list: straight key + element-specific note
-      const notes: number[] = [];
-      if (s.midiOutputStraightKeyNote >= 0) notes.push(s.midiOutputStraightKeyNote);
-      if (element === '.' && s.midiOutputDitNote >= 0) notes.push(s.midiOutputDitNote);
-      if (element === '-' && s.midiOutputDahNote >= 0) notes.push(s.midiOutputDahNote);
+      // Fire notes for every enabled mapping
+      const fired: { note: number; channel: number; output: MIDIOutput }[] = [];
+      for (const mapping of enabledMappings) {
+        const output = this.getOutputForDevice(mapping.deviceId);
+        if (!output) continue;
 
-      if (notes.length > 0) {
-        for (const note of notes) this.sendNoteOn(note, velocity, channel);
-        await this.sleepMs(duration);
-        for (const note of notes) this.sendNoteOff(note, channel);
-      } else {
-        await this.sleepMs(duration);
+        if (mapping.mode === 'straightKey') {
+          // Straight key fires on every element
+          if (mapping.value >= 0) {
+            this.sendNoteOn(mapping.value, velocity, mapping.channel, output);
+            fired.push({ note: mapping.value, channel: mapping.channel, output });
+          }
+        } else {
+          // Paddle mode: dit note for '.', dah note for '-'
+          if (element === '.' && mapping.value >= 0) {
+            this.sendNoteOn(mapping.value, velocity, mapping.channel, output);
+            fired.push({ note: mapping.value, channel: mapping.channel, output });
+          }
+          if (element === '-' && mapping.dahValue >= 0) {
+            this.sendNoteOn(mapping.dahValue, velocity, mapping.channel, output);
+            fired.push({ note: mapping.dahValue, channel: mapping.channel, output });
+          }
+        }
+      }
+
+      await this.sleepMs(duration);
+
+      // Release all notes fired for this element
+      for (const { note, channel, output } of fired) {
+        this.sendNoteOff(note, channel, output);
       }
 
       // Intra-character gap
@@ -416,10 +465,13 @@ export class MidiOutputService implements OnDestroy {
    * Not called for MIDI-originated inputs (fromMidi) to prevent echo loops.
    */
   keyDown(source: 'rx' | 'tx' = 'tx'): void {
-    if (!this.canOutput(source)) return;
+    if (!this.isActive()) return;
     const s = this.settings.settings();
-    if (s.midiOutputStraightKeyNote >= 0) {
-      this.sendNoteOn(s.midiOutputStraightKeyNote, s.midiOutputVelocity, s.midiOutputChannel);
+    const velocity = 127;
+    for (const mapping of s.midiOutputMappings) {
+      if (!mapping.enabled || mapping.mode !== 'straightKey') continue;      if (mapping.forward !== 'both' && mapping.forward !== source) continue;      const output = this.getOutputForDevice(mapping.deviceId);
+      if (!output || mapping.value < 0) continue;
+      this.sendNoteOn(mapping.value, velocity, mapping.channel, output);
     }
   }
 
@@ -430,34 +482,32 @@ export class MidiOutputService implements OnDestroy {
    * the method checks activeNotes before sending.
    */
   keyUp(): void {
-    if (!this.activeOutput) return;
-    const s = this.settings.settings();
-    if (s.midiOutputStraightKeyNote >= 0 && this.activeNotes.has(s.midiOutputStraightKeyNote)) {
-      this.sendNoteOff(s.midiOutputStraightKeyNote, s.midiOutputChannel);
+    // Release all active straight-key notes
+    for (const [key, info] of this.activeNotes) {
+      this.sendNoteOff(info.note, info.channel, info.output);
     }
   }
 
   /**
-   * Test output — send a 1-second pulse on the straight key note.
+   * Test a specific mapping — send a 1-second pulse on the given note/channel.
+   * Called from the MIDI output edit modal's test button.
    */
-  async test(): Promise<void> {
-    if (!this.activeOutput) return;
-    const s = this.settings.settings();
-    const note = s.midiOutputStraightKeyNote;
-    if (note < 0) return;
-    this.sendNoteOn(note, s.midiOutputVelocity, s.midiOutputChannel);
+  async testMapping(note: number, channel: number, deviceId: string = ''): Promise<void> {
+    const output = this.getOutputForDevice(deviceId);
+    if (!output || note < 0) return;
+    this.sendNoteOn(note, 127, channel, output);
     await new Promise(resolve => setTimeout(resolve, 1000));
-    this.sendNoteOff(note, s.midiOutputChannel);
+    this.sendNoteOff(note, channel, output);
   }
 
   // ---- Internal MIDI message methods ----
 
-  private sendNoteOn(note: number, velocity: number, channel: number): void {
-    if (!this.activeOutput || note < 0 || note > 127) return;
+  private sendNoteOn(note: number, velocity: number, channel: number, output: MIDIOutput): void {
+    if (note < 0 || note > 127) return;
     // MIDI note-on: 0x90 + channel (0-based)
     const status = 0x90 | ((channel - 1) & 0x0f);
-    this.activeOutput.send([status, note, velocity & 0x7f]);
-    this.activeNotes.add(note);
+    output.send([status, note, velocity & 0x7f]);
+    this.activeNotes.set(`${note}:${channel}`, { note, channel, output });
     // Cancel any pending holdoff — we are actively sending again
     if (this.isSendingHoldoff) {
       clearTimeout(this.isSendingHoldoff);
@@ -466,12 +516,12 @@ export class MidiOutputService implements OnDestroy {
     this.isSending.set(true);
   }
 
-  private sendNoteOff(note: number, channel: number): void {
-    if (!this.activeOutput || note < 0 || note > 127) return;
+  private sendNoteOff(note: number, channel: number, output: MIDIOutput): void {
+    if (note < 0 || note > 127) return;
     // MIDI note-off: 0x80 + channel (0-based)
     const status = 0x80 | ((channel - 1) & 0x0f);
-    this.activeOutput.send([status, note, 0]);
-    this.activeNotes.delete(note);
+    output.send([status, note, 0]);
+    this.activeNotes.delete(`${note}:${channel}`);
     if (this.activeNotes.size === 0) {
       // Don't clear isSending immediately — start a holdoff timer so
       // the physical bus has time to settle before MIDI input is unmuted.
@@ -488,22 +538,19 @@ export class MidiOutputService implements OnDestroy {
     }
   }
 
-  /** Check whether output should be active for the given source */
-  private canOutput(source: 'rx' | 'tx'): boolean {
-    if (!this.activeOutput) return false;
+  /** Check whether MIDI output is globally active */
+  private isActive(): boolean {
+    if (!this.midiAccess) return false;
     const s = this.settings.settings();
     if (!s.midiOutputEnabled) return false;
-    if (s.midiOutputForward !== 'both' && s.midiOutputForward !== source) return false;
     return true;
   }
 
   /** Release all currently held notes */
   private releaseAll(): void {
-    if (!this.activeOutput) return;
-    const s = this.settings.settings();
-    const channel = s.midiOutputChannel;
-    for (const note of this.activeNotes) {
-      this.sendNoteOff(note, channel);
+    for (const [, info] of this.activeNotes) {
+      const status = 0x80 | ((info.channel - 1) & 0x0f);
+      info.output.send([status, info.note, 0]);
     }
     this.activeNotes.clear();
     // Immediate clear — no holdoff needed when explicitly releasing all
@@ -522,14 +569,14 @@ export class MidiOutputService implements OnDestroy {
     if (!this.midiAccess) return;
     this.midiAccess.onstatechange = () => {
       this.zone.run(() => this.refreshOutputs());
-      this.resolveActiveOutput();
+      this.updateConnected();
       // Retry after short delays for ports that need time to settle
       // after a physical reconnection.
       for (const delay of [500, 1500]) {
         setTimeout(() => {
           if (this.started && this.midiAccess) {
             this.zone.run(() => this.refreshOutputs());
-            this.resolveActiveOutput();
+            this.updateConnected();
           }
         }, delay);
       }
@@ -546,30 +593,35 @@ export class MidiOutputService implements OnDestroy {
       }
     }
     this.midiOutputs.set(outputs);
-    this.connected.set(this.activeOutput !== null && outputs.length > 0);
+    this.connected.set(outputs.length > 0);
   }
 
-  /** Resolve the active MIDI output port from settings */
-  private resolveActiveOutput(): void {
-    if (!this.midiAccess) return;
-    const configuredId = this.settings.settings().midiOutputDeviceId;
-    let found: MIDIOutput | null = null;
-
+  /**
+   * Resolve a MIDI output port for the given device ID.
+   * If deviceId is empty, returns the first available connected output.
+   */
+  getOutputForDevice(deviceId: string): MIDIOutput | null {
+    if (!this.midiAccess) return null;
+    let first: MIDIOutput | null = null;
     for (const output of this.midiAccess.outputs.values()) {
       if (output.state !== 'connected') continue;
-      if (configuredId && output.id === configuredId) {
-        found = output;
-        break;
-      }
-      if (!configuredId && !found) {
-        found = output; // First available if none configured
-      }
+      if (deviceId && output.id === deviceId) return output;
+      if (!first) first = output;
     }
+    return deviceId ? null : first;
+  }
 
-    this.activeOutput = found;
-    this.zone.run(() => {
-      this.connected.set(found !== null);
-    });
+  /** Update the connected signal based on available outputs */
+  private updateConnected(): void {
+    if (!this.midiAccess) {
+      this.zone.run(() => this.connected.set(false));
+      return;
+    }
+    let hasOutput = false;
+    for (const output of this.midiAccess.outputs.values()) {
+      if (output.state === 'connected') { hasOutput = true; break; }
+    }
+    this.zone.run(() => this.connected.set(hasOutput));
   }
 
   private installKeepAlive(): void {
@@ -577,7 +629,7 @@ export class MidiOutputService implements OnDestroy {
     this.keepAliveTimer = setInterval(() => {
       if (!this.started || !this.midiAccess) return;
       this.zone.run(() => this.refreshOutputs());
-      this.resolveActiveOutput();
+      this.updateConnected();
     }, 5000);
   }
 

--- a/src/app/services/morse-decoder.service.ts
+++ b/src/app/services/morse-decoder.service.ts
@@ -21,6 +21,10 @@ export interface DecoderKeyOptions {
   fromMidi?: boolean;
   /** True when the event originated from serial input (prevents echo loops) */
   fromSerial?: boolean;
+  /** Optional display name (e.g. MIDI mapping name or RTDB callsign) */
+  name?: string;
+  /** Optional text colour override (CSS colour string from MIDI mapping) */
+  color?: string;
 }
 
 /**
@@ -38,6 +42,8 @@ interface DecoderPipeline {
   perfectTiming: boolean;
   fromMidi: boolean;
   fromSerial: boolean;
+  name: string;
+  color: string;
   keyDownTime: number;
   keyUpTime: number;
   silenceTimer: ReturnType<typeof setTimeout> | null;
@@ -126,7 +132,8 @@ export class MorseDecoderService {
     type: 'rx' | 'tx';
     char: string;
     inputPath?: InputPath;
-    userName?: string;
+    name?: string;
+    color?: string;
     fromRtdb?: boolean;
     fromMidi?: boolean;
     fromSerial?: boolean;
@@ -427,6 +434,8 @@ export class MorseDecoderService {
         perfectTiming: opts?.perfectTiming ?? false,
         fromMidi: opts?.fromMidi ?? false,
         fromSerial: opts?.fromSerial ?? false,
+        name: opts?.name ?? '',
+        color: opts?.color ?? '',
         keyDownTime: 0,
         keyUpTime: 0,
         silenceTimer: null,
@@ -442,6 +451,8 @@ export class MorseDecoderService {
       pipeline.perfectTiming = opts?.perfectTiming ?? false;
       pipeline.fromMidi = opts?.fromMidi ?? false;
       pipeline.fromSerial = opts?.fromSerial ?? false;
+      pipeline.name = opts?.name ?? '';
+      pipeline.color = opts?.color ?? '';
     }
     return pipeline;
   }
@@ -564,8 +575,10 @@ export class MorseDecoderService {
     this.decodedText.update(t => t + char);
     const fromMidi = pipeline.fromMidi || undefined;
     const fromSerial = pipeline.fromSerial || undefined;
+    const name = pipeline.name || undefined;
+    const color = pipeline.color || undefined;
     this.taggedOutput.update(arr => [...arr, {
-      type: pipeline.source, char, inputPath: path, wpm, fromMidi, fromSerial,
+      type: pipeline.source, char, inputPath: path, wpm, fromMidi, fromSerial, name, color,
     }]);
     pipeline.pattern = '';
     // A real character was decoded — allow a future trailing space
@@ -605,9 +618,11 @@ export class MorseDecoderService {
       const wpm = this.pipelineWpm(pipeline);
       const fromMidi = pipeline.fromMidi || undefined;
       const fromSerial = pipeline.fromSerial || undefined;
+      const name = pipeline.name || undefined;
+      const color = pipeline.color || undefined;
       this.decodedText.update(t => t + ' ');
       this.taggedOutput.update(arr => [...arr, {
-        type: pipeline.source, char: ' ', inputPath: path, wpm, fromMidi, fromSerial,
+        type: pipeline.source, char: ' ', inputPath: path, wpm, fromMidi, fromSerial, name, color,
       }]);
     }
   }

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -69,6 +69,52 @@ export interface ProsignActionEntry {
   action: ProsignAction;
 }
 
+/** Mode for a MIDI input mapping entry */
+export type MidiInputMode = 'straightKey' | 'paddle';
+
+/** Mode for a MIDI output mapping entry */
+export type MidiOutputMode = 'straightKey' | 'paddle';
+
+/** Configuration for a single MIDI input mapping */
+export interface MidiInputMapping {
+  enabled: boolean;
+  /** MIDI input device ID (empty = any/first available) */
+  deviceId: string;
+  /** MIDI channel filter: 0 = omni (all channels), 1-16 = specific channel */
+  channel: number;
+  /** Decoder source: which calibration pool this input feeds ('rx' or 'tx') */
+  source: DecoderSource;
+  /** Mode: straight key or paddle */
+  mode: MidiInputMode;
+  /** MIDI note number for straight key, or dit paddle (-1 = not assigned) */
+  value: number;
+  /** MIDI note number for dah paddle (only used when mode is 'paddle', -1 = not assigned) */
+  dahValue: number;
+  /** Reverse paddles (only used when mode is 'paddle') */
+  reversePaddles: boolean;
+  /** Optional display name (e.g. callsign) — triggers line breaks in conversation views */
+  name: string;
+  /** Optional text color (CSS color string) — overrides RX/TX default in fullscreen views */
+  color: string;
+}
+
+/** Configuration for a single MIDI output mapping */
+export interface MidiOutputMapping {
+  enabled: boolean;
+  /** MIDI output device ID (empty = any/first available) */
+  deviceId: string;
+  /** MIDI channel (1-16) */
+  channel: number;
+  /** Output forwarding mode: which signal source drives this mapping */
+  forward: OutputForward;
+  /** Mode: straight key or paddle */
+  mode: MidiOutputMode;
+  /** MIDI note number for straight key, or dit paddle */
+  value: number;
+  /** MIDI note number for dah paddle (only used when mode is 'paddle', -1 = not assigned) */
+  dahValue: number;
+}
+
 /** Configuration for a single emoji replacement mapping */
 export interface EmojiMapping {
   enabled: boolean;
@@ -163,7 +209,7 @@ export interface AppSettings {
   rtdbOutputForward: OutputForward;
   rtdbOutputChannelName: string;
   rtdbOutputChannelSecret: string;
-  rtdbOutputUserName: string;
+  rtdbOutputName: string;
 
   // --- 3. Audio Output (sidetone / headphone / speaker) ---
   sidetoneOutputDeviceId: string;
@@ -222,38 +268,12 @@ export interface AppSettings {
 
   // --- MIDI Input ---
   midiInputEnabled: boolean;
-  /** Decoder source for MIDI straight key ('rx' or 'tx') */
-  midiStraightKeySource: DecoderSource;
-  /** Decoder source for MIDI paddle ('rx' or 'tx') */
-  midiPaddleSource: DecoderSource;
-  /** MIDI input device ID (empty = any/first available) */
-  midiInputDeviceId: string;
-  /** MIDI channel filter: 0 = omni (all channels), 1-16 = specific channel */
-  midiInputChannel: number;
-  /** MIDI note number for straight key (-1 = not assigned) */
-  midiStraightKeyNote: number;
-  /** MIDI note number for dit paddle (-1 = not assigned) */
-  midiDitNote: number;
-  /** MIDI note number for dah paddle (-1 = not assigned) */
-  midiDahNote: number;
-  /** Reverse paddles for MIDI paddle input */
-  midiReversePaddles: boolean;
+  /** Ordered list of MIDI input mappings (straight key / paddle entries) */
+  midiInputMappings: MidiInputMapping[];
   // --- MIDI Output ---
   midiOutputEnabled: boolean;
-  /** MIDI output device ID (empty = first available) */
-  midiOutputDeviceId: string;
-  /** MIDI channel for output (1-16) */
-  midiOutputChannel: number;
-  /** MIDI note number for straight key output (-1 = not assigned) */
-  midiOutputStraightKeyNote: number;
-  /** MIDI note number for dit paddle output (-1 = not assigned) */
-  midiOutputDitNote: number;
-  /** MIDI note number for dah paddle output (-1 = not assigned) */
-  midiOutputDahNote: number;
-  /** MIDI velocity for note-on messages (0-127, default 127) */
-  midiOutputVelocity: number;
-  /** Output forwarding mode: which signal source drives MIDI output */
-  midiOutputForward: OutputForward;
+  /** Ordered list of MIDI output mappings (straight key / paddle entries) */
+  midiOutputMappings: MidiOutputMapping[];
   /** When true, ignore remote WPM and use local encoder WPM for MIDI output */
   midiOutputOverrideWpm: boolean;
 
@@ -381,7 +401,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   rtdbOutputForward: 'tx',
   rtdbOutputChannelName: '',
   rtdbOutputChannelSecret: '',
-  rtdbOutputUserName: '',
+  rtdbOutputName: '',
 
   sidetoneOutputDeviceId: 'default',
   sidetoneOutputChannel: 'left',
@@ -425,23 +445,54 @@ const DEFAULT_SETTINGS: AppSettings = {
   touchReversePaddles: false,
 
   midiInputEnabled: false,
-  midiStraightKeySource: 'rx',
-  midiPaddleSource: 'rx',
-  midiInputDeviceId: '',
-  midiInputChannel: 0,
-  midiStraightKeyNote: 60,
-  midiDitNote: 62,
-  midiDahNote: 64,
-  midiReversePaddles: false,
+  midiInputMappings: [
+    {
+      enabled: true,
+      deviceId: '',
+      channel: 0,
+      source: 'rx',
+      mode: 'straightKey',
+      value: 60,
+      dahValue: -1,
+      reversePaddles: false,
+      name: '',
+      color: '',
+    },
+    {
+      enabled: true,
+      deviceId: '',
+      channel: 0,
+      source: 'rx',
+      mode: 'paddle',
+      value: 62,
+      dahValue: 64,
+      reversePaddles: false,
+      name: '',
+      color: '',
+    },
+  ],
 
   midiOutputEnabled: false,
-  midiOutputDeviceId: '',
-  midiOutputChannel: 1,
-  midiOutputStraightKeyNote: 66,
-  midiOutputDitNote: 68,
-  midiOutputDahNote: 70,
-  midiOutputVelocity: 127,
-  midiOutputForward: 'tx',
+  midiOutputMappings: [
+    {
+      enabled: true,
+      deviceId: '',
+      channel: 1,
+      forward: 'tx',
+      mode: 'straightKey',
+      value: 80,
+      dahValue: -1,
+    },
+    {
+      enabled: true,
+      deviceId: '',
+      channel: 1,
+      forward: 'tx',
+      mode: 'paddle',
+      value: 82,
+      dahValue: 84,
+    },
+  ],
   midiOutputOverrideWpm: false,
 
   rtdbInputEnabled: false,
@@ -673,6 +724,7 @@ export class SettingsService {
       // Ensure nested collections have all expected keys (e.g. new prosign
       // keys added after the profile was saved).
       this.backfillProsignActions();
+      this.backfillMidiOutputMappings();
       this.isDirty.set(false);
       this.needsValidation.set(false);
       return true;
@@ -731,6 +783,26 @@ export class SettingsService {
     this.modalDisplay.set({ ...DEFAULT_MODAL_DISPLAY });
     localStorage.setItem(MODAL_DISPLAY_KEY, JSON.stringify(DEFAULT_MODAL_DISPLAY));
     this.isDirty.set(true);
+  }
+
+  /**
+   * Ensure every MIDI output mapping has a 'forward' field.
+   * Profiles saved before forward was moved from global to per-mapping
+   * will have mappings without it; default to 'tx'.
+   */
+  private backfillMidiOutputMappings(): void {
+    const s = this.settings();
+    let patched = false;
+    const mappings = s.midiOutputMappings.map(m => {
+      if (!m.forward) {
+        patched = true;
+        return { ...m, forward: ((s as any).midiOutputForward || 'tx') as OutputForward };
+      }
+      return m;
+    });
+    if (patched) {
+      this.settings.set({ ...s, midiOutputMappings: mappings });
+    }
   }
 
   /**

--- a/src/app/version.ts
+++ b/src/app/version.ts
@@ -1,2 +1,2 @@
 /** Single source of truth for the application version displayed in the UI. */
-export const APP_VERSION = '1.0.0';
+export const APP_VERSION = '1.1.0';


### PR DESCRIPTION
## Description

MIDI input now supports multiple independent mappings in a table-based interface.  
Each MIDI input mapping can now have an optional **Name** (e.g. a callsign) and **Colour** (CSS colour string).  
MIDI output now supports multiple independent mappings in the same table + edit modal pattern as MIDI input.
Both the ATmega32U4 and nRF52840 sketches now expose all 16 usable GPIO pins as individually configurable slots, each with a direction (input/output), MIDI channel, and MIDI note. The previous 3-input / 3-output fixed assignment has been replaced by a fully table-driven configuration at the top of each sketch.  

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] My code follows the existing code style of the project
- [X] The app builds without errors (`ng build`)
- [ ] I have run the tests (`ng test`) and they pass
- [X] I have tested my changes in Chrome or Edge
- [X] I have added/updated documentation as needed

