### PR TITLE
v1.4.0 inputs tagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-03-14
+
+### Added
+
+- **Input Name & Colour Tagging** — Mouse Keyer, Touch Keyer, CW Tone
+  Detector, and Straight Key via Mic now support optional **Name** and
+  **Colour** fields, matching the existing pattern in Keyboard, MIDI, and
+  Serial inputs. When a name is set, switching between inputs triggers a
+  line break in conversation views. Colour overrides the default RX/TX
+  colour in fullscreen views.
+- **Firebase RTDB Output Colour** — RTDB output can now optionally send a
+  colour (`col` parameter) alongside each character. Remote listeners
+  display this colour in their fullscreen views.
+- **RTDB Name & Colour Override Checkboxes** — Two new checkboxes on the
+  RTDB Output card control whether the RTDB output name and colour always
+  override input-specific tags, or serve as fallbacks when no input-specific
+  tag is defined.
+- **Firebase RTDB Input Name & Colour Override** — RTDB input now supports
+  optional override fields for both name and colour. When set, they replace
+  the incoming sender's tag; when empty, the remote sender's name/colour is
+  preserved.
+- **RTDB Echo Suppression for Input-Specific Names** — The echo filter now
+  tracks all names sent (including input-specific names), preventing echoes
+  when multiple named inputs are forwarded through the same RTDB channel.
+
+### Changed
+
+- **RTDB Mandatory Fields** — Channel Name, Channel Secret, and Name are now
+  mandatory for RTDB Output. Channel Name and Channel Secret are mandatory
+  for RTDB Input. Fields show a red asterisk and red label/border when
+  empty. Enabling the toggle is blocked with an error message until all
+  required fields are filled. Clearing a required field while enabled
+  auto-disables the service.
+
 ## [1.3.0] - 2026-03-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Connect a physical key or paddle, and decoded Morse code appears instantly on a 
 
 **Key Your Radio** — Drives your transmitter's keying line through multiple output methods: Arduino MIDI optocoupler (multiple mappings with per-mapping forward selectors), sound card optocoupler (DC or AC mode), USB-serial adapter (multiple mappings with per-mapping DTR/RTS pin, invert, and forward selectors via Web Serial API), or WinKeyer.
 
-**Online Relay** — Relay Morse characters between app instances in real time over the internet via Firebase Realtime Database. Each character carries the sender's WPM so the receiving station plays it back at the original rhythm. Channels use a name + secret pair for access control, with callsign-prefixed lines in the fullscreen conversation view.
+**Online Relay** — Relay Morse characters between app instances in real time over the internet via Firebase Realtime Database. Each character carries the sender's WPM and optional colour so the receiving station plays it back at the original rhythm. Channels use a name + secret pair for access control, with callsign-prefixed lines in the fullscreen conversation view. Input-specific names and colours are forwarded by default, with optional overrides on both the sending and receiving side.
 
 ## Connecting Your Key and Radio
 
@@ -34,7 +34,7 @@ Multiple MIDI devices can be used simultaneously — each MIDI Input and MIDI Ou
 
 ### Keyboard, Mouse and Touch
 
-The built-in keyboard, mouse, and touch keyers require no extra hardware — convenient for practice and portable use. All five keyer modes are supported. The keyboard keyer supports **multiple independent mappings**, each with its own mode (straight key or paddle), key bindings, paddle mode, decoder source (RX/TX), reverse paddles toggle, and optional **Name** and **Colour** for multi-user conversation views. The main limitation is that **the browser tab must be in focus** to receive these events, so they are not suitable for background operation.
+The built-in keyboard, mouse, and touch keyers require no extra hardware — convenient for practice and portable use. All five keyer modes are supported. The keyboard keyer supports **multiple independent mappings**, each with its own mode (straight key or paddle), key bindings, paddle mode, decoder source (RX/TX), reverse paddles toggle, and optional **Name** and **Colour** for multi-user conversation views. The mouse and touch keyers also support optional **Name** and **Colour**. The main limitation is that **the browser tab must be in focus** to receive these events, so they are not suitable for background operation.
 
 ### Serial Port (Web Serial API)
 
@@ -58,7 +58,7 @@ For stations using a K1EL WinKeyer (WK2/WK3/WKUSB), the app can forward decoded 
 
 ### Sound Card (Experimental)
 
-The sound card can serve double duty: an **optocoupler output** (DC or AC mode) keys the transmitter via the headphone jack, while **microphone input** with ultrasonic pilot-tone detection reads a physical key's closures. CW tone decoding of received audio works well and is the primary decode path for most setups. The keying input side (pilot-tone detection) is experimental and sensitive to audio hardware latency, so MIDI remains the more robust choice for key input.
+The sound card can serve double duty: an **optocoupler output** (DC or AC mode) keys the transmitter via the headphone jack, while **microphone input** with ultrasonic pilot-tone detection reads a physical key's closures. CW tone decoding of received audio works well and is the primary decode path for most setups; both the CW tone detector and the pilot-tone key input support optional **Name** and **Colour** for multi-user conversation views. The keying input side (pilot-tone detection) is experimental and sensitive to audio hardware latency, so MIDI remains the more robust choice for key input.
 
 ## Signal Routing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "morse-code-studio",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "morse-code-studio",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@angular/animations": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morse-code-studio",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A browser-based Morse code encoder, decoder and keyer built with Angular and the Web Audio API",
   "author": "5B4AON — Mike",
   "repository": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -210,7 +210,7 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
 
           // Forward to RTDB output only for non-RTDB chars (prevent echo)
           if (!entry.fromRtdb) {
-            this.rtdbService.forwardDecodedChar(entry.char, entry.type, entry.wpm);
+            this.rtdbService.forwardDecodedChar(entry.char, entry.type, entry.wpm, entry.name, entry.color);
           }
         }
       }
@@ -296,11 +296,13 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
     this.subs.push(
       this.audioInput.keyEvent$.subscribe(evt => {
         this.micKeyDown = evt.down;
-        const source = this.settings.settings().micInputSource;
+        const s = this.settings.settings();
+        const source = s.micInputSource;
+        const opts = { name: s.micInputName || undefined, color: s.micInputColor || undefined };
         if (evt.down) {
-          this.decoder.onKeyDown('mic', source);
+          this.decoder.onKeyDown('mic', source, opts);
         } else {
-          this.decoder.onKeyUp('mic', source);
+          this.decoder.onKeyUp('mic', source, opts);
         }
       })
     );
@@ -319,11 +321,13 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
     this.subs.push(
       this.cwInput.keyEvent$.subscribe(evt => {
         this.cwKeyDown = evt.down;
-        const source = this.settings.settings().cwInputSource;
+        const s = this.settings.settings();
+        const source = s.cwInputSource;
+        const opts = { name: s.cwInputName || undefined, color: s.cwInputColor || undefined };
         if (evt.down) {
-          this.decoder.onKeyDown('cwAudio', source);
+          this.decoder.onKeyDown('cwAudio', source, opts);
         } else {
-          this.decoder.onKeyUp('cwAudio', source);
+          this.decoder.onKeyUp('cwAudio', source, opts);
         }
       })
     );
@@ -341,10 +345,14 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
 
     // Firebase RTDB incoming characters → decoder display + sidetone only
     this.subs.push(
-      this.rtdbService.incomingChar$.subscribe(({ char, source, name, wpm }) => {
+      this.rtdbService.incomingChar$.subscribe(({ char, source, name, wpm, color }) => {
         // Add to decoder tagged output so it appears in conversation / fullscreen
         // Mark fromRtdb so the forwarding effect doesn't echo it back to RTDB
-        this.decoder.taggedOutput.update(arr => [...arr, { type: source, char, name, fromRtdb: true, wpm }]);
+        // Apply input name/color overrides (non-empty = override, empty = preserve incoming)
+        const s = this.settings.settings();
+        const effectiveName = s.rtdbInputName.trim() || name;
+        const effectiveColor = s.rtdbInputColor.trim() || color;
+        this.decoder.taggedOutput.update(arr => [...arr, { type: source, char, name: effectiveName, color: effectiveColor, fromRtdb: true, wpm }]);
         this.decoder.decodedText.update(t => t + char);
         // Play through all outputs whose forward mode matches the source
         // Use remote WPM unless the user has chosen to override with local encoder WPM

--- a/src/app/components/fullscreen-modal/fs-decoder-view/fs-decoder-view.component.ts
+++ b/src/app/components/fullscreen-modal/fs-decoder-view/fs-decoder-view.component.ts
@@ -160,17 +160,18 @@ export class FsDecoderViewComponent implements OnInit, OnDestroy, OnChanges, Aft
   private dispatchTouchButton(button: 'straight' | 'left' | 'right', down: boolean): void {
     const s = this.settings.settings();
     const source = s.touchKeyerSource;
+    const opts = { name: s.touchKeyerName || undefined, color: s.touchKeyerColor || undefined };
     if (button === 'straight') {
-      this.keyer.straightKeyInput(down, source, false, 'touchStraightKey');
+      this.keyer.straightKeyInput(down, source, false, 'touchStraightKey', opts);
       return;
     }
     const reverse = s.touchReversePaddles;
     const element = button === 'left' ? 'dit' : 'dah';
     const effective = reverse ? (element === 'dit' ? 'dah' : 'dit') : element;
     if (effective === 'dit') {
-      this.keyer.ditPaddleInput(down, source, false, 'touchPaddle', s.touchPaddleMode);
+      this.keyer.ditPaddleInput(down, source, false, 'touchPaddle', s.touchPaddleMode, opts);
     } else {
-      this.keyer.dahPaddleInput(down, source, false, 'touchPaddle', s.touchPaddleMode);
+      this.keyer.dahPaddleInput(down, source, false, 'touchPaddle', s.touchPaddleMode, opts);
     }
   }
 

--- a/src/app/components/help/help-ch-firebase.component.html
+++ b/src/app/components/help/help-ch-firebase.component.html
@@ -96,6 +96,16 @@
         Encoder WPM instead of the sender&rsquo;s original speed.
         Default: off (remote WPM is respected for realistic timing).</td>
   </tr>
+  <tr>
+    <td><strong>Override Name</strong></td>
+    <td>If set, replaces the incoming sender name with this value.
+        Leave empty to preserve the remote sender&rsquo;s name.</td>
+  </tr>
+  <tr>
+    <td><strong>Override Colour</strong></td>
+    <td>If set, overrides the incoming colour. Leave cleared to use
+        the sender&rsquo;s colour (or the default RX/TX colour).</td>
+  </tr>
 </table>
 
 <p>
@@ -147,10 +157,32 @@
   </tr>
   <tr>
     <td><strong>User Name</strong></td>
-    <td>Your callsign or name. This is shown as a prefix
+    <td>Your callsign or name (mandatory). This is shown as a prefix
         (e.g. <strong>[CALLSIGN]</strong>) on each line in the remote
         station's fullscreen conversation view, so they know who is
-        sending.</td>
+        sending. When text is typed via the keyboard encoder, this
+        name is always used.</td>
+  </tr>
+  <tr>
+    <td><strong>Override input name</strong></td>
+    <td>When checked, the User Name above is always sent, overriding
+        any input-specific name (e.g. from Mouse Keyer or CW Detector).
+        When unchecked (default), input-specific names are sent if
+        defined; otherwise the User Name is used as fallback.</td>
+  </tr>
+  <tr>
+    <td><strong>Colour</strong></td>
+    <td>Optional CSS colour sent alongside each character. Remote
+        listeners display this colour in their fullscreen views.
+        When text is typed via the keyboard encoder, this colour is
+        always used.</td>
+  </tr>
+  <tr>
+    <td><strong>Override input colour</strong></td>
+    <td>When checked, the Colour above is always sent, overriding
+        any input-specific colour. When unchecked (default),
+        input-specific colours are sent if defined; otherwise this
+        colour is used as fallback.</td>
   </tr>
   <tr>
     <td><strong>Forward</strong></td>

--- a/src/app/components/help/help-ch-inputs.component.html
+++ b/src/app/components/help/help-ch-inputs.component.html
@@ -51,7 +51,16 @@
   <li><strong>Used for</strong> — Decoder source (RX or TX). See
       <em>Chapter 5: Decoder Source Routing</em>.</li>
 </ul>
-
+<h3>Name &amp; Colour</h3>
+<p>
+  The CW Tone Detector has optional <strong>Name</strong> and
+  <strong>Colour</strong> fields. When a name is set (e.g. a callsign
+  or station identifier), decoded text from this input appears on a new
+  line in the fullscreen conversation view, prefixed with the name in
+  square brackets. If a colour is set, the text uses that colour instead
+  of the default RX/TX colour. These tags also propagate to Firebase RTDB
+  output (unless overridden by the RTDB output settings).
+</p>
 <div class="example-box">
   <div class="example-title">Example — Decoding with a virtual audio cable</div>
   <p>
@@ -613,6 +622,14 @@
   <li><strong>Used for</strong> — Decoder source (RX or TX). See
       <em>Chapter 5: Decoder Source Routing</em>.</li>
 </ul>
+
+<h3>Name &amp; Colour</h3>
+<p>
+  Like the CW Tone Detector (&sect;6.1), the Straight Key via Mic input
+  has optional <strong>Name</strong> and <strong>Colour</strong> fields.
+  When set, decoded text appears on a colour-coded, named line in the
+  fullscreen conversation view.
+</p>
 
 <div class="example-box">
   <div class="example-title">Calibrating the threshold</div>

--- a/src/app/components/help/help-ch-keyers.component.html
+++ b/src/app/components/help/help-ch-keyers.component.html
@@ -159,6 +159,17 @@
   <strong>Keyer WPM</strong> settings with the keyboard and touch keyers.
 </p>
 
+<h3>Name &amp; Colour</h3>
+<p>
+  The mouse keyer has optional <strong>Name</strong> and
+  <strong>Colour</strong> fields. When a name is set (e.g. a callsign),
+  decoded text from the mouse keyer appears on a new line in the
+  fullscreen conversation view, prefixed with <strong>[Name]</strong>.
+  If a colour is set, the text is rendered in that colour instead of the
+  default RX/TX colour. These tags also propagate to Firebase RTDB output
+  (unless overridden by the RTDB output settings).
+</p>
+
 <!-- 4.3 Touch Keyer -->
 <h2 id="s4-3">4.3 &nbsp;Touch Keyer</h2>
 
@@ -196,6 +207,14 @@
 <p>
   The touch keyer shares <strong>Paddle Mode</strong> and
   <strong>Keyer WPM</strong> with the keyboard and mouse keyers.
+</p>
+
+<h3>Name &amp; Colour</h3>
+<p>
+  The touch keyer has optional <strong>Name</strong> and
+  <strong>Colour</strong> fields, identical in behaviour to the mouse
+  keyer. When set, decoded text appears on a colour-coded, named line
+  in the fullscreen conversation view.
 </p>
 
 <h3>Haptic Vibration</h3>

--- a/src/app/components/settings-modal/settings-inputs-tab/cw-detector-card/cw-detector-card.component.html
+++ b/src/app/components/settings-modal/settings-inputs-tab/cw-detector-card/cw-detector-card.component.html
@@ -95,6 +95,30 @@
         Feed audio from your radio receiver, virtual audio cable, or any audio source carrying CW tones.
         The detector uses a narrow Goertzel filter at the configured frequency with automatic gain tracking.
       </div>
+
+      <div class="card-section-divider"></div>
+
+      <label>Name:
+        <input type="text" [value]="settings.settings().cwInputName"
+               (input)="onSettingChange('cwInputName', $event)"
+               placeholder="e.g. callsign (optional)"
+               maxlength="20">
+      </label>
+      <div class="cw-hint">Triggers a line break in conversation views when a different name appears.</div>
+
+      <label>Color:
+        <div class="card-color-row">
+          <input type="color" class="card-color-picker"
+                 [ngModel]="settings.settings().cwInputColor || '#ffffff'"
+                 (ngModelChange)="settings.update({ cwInputColor: $event })">
+          @if (settings.settings().cwInputColor) {
+            <button type="button" class="card-color-clear"
+                    (click)="settings.update({ cwInputColor: '' })" title="Clear color">&#10005;</button>
+          }
+          <span class="card-color-preview" [style.color]="settings.settings().cwInputColor || 'inherit'">Sample</span>
+        </div>
+      </label>
+      <div class="cw-hint">Optional. Overrides the default RX/TX colour in fullscreen views.</div>
     </div>
   }
 </div>

--- a/src/app/components/settings-modal/settings-inputs-tab/mic-card/mic-card.component.html
+++ b/src/app/components/settings-modal/settings-inputs-tab/mic-card/mic-card.component.html
@@ -102,6 +102,30 @@
                (change)="onInputInvertChange($event)">
         Invert key sense
       </label>
+
+      <div class="card-section-divider"></div>
+
+      <label>Name:
+        <input type="text" [value]="settings.settings().micInputName"
+               (input)="onSettingChange('micInputName', $event)"
+               placeholder="e.g. callsign (optional)"
+               maxlength="20">
+      </label>
+      <div class="cw-hint">Triggers a line break in conversation views when a different name appears.</div>
+
+      <label>Color:
+        <div class="card-color-row">
+          <input type="color" class="card-color-picker"
+                 [ngModel]="settings.settings().micInputColor || '#ffffff'"
+                 (ngModelChange)="settings.update({ micInputColor: $event })">
+          @if (settings.settings().micInputColor) {
+            <button type="button" class="card-color-clear"
+                    (click)="settings.update({ micInputColor: '' })" title="Clear color">&#10005;</button>
+          }
+          <span class="card-color-preview" [style.color]="settings.settings().micInputColor || 'inherit'">Sample</span>
+        </div>
+      </label>
+      <div class="cw-hint">Optional. Overrides the default RX/TX colour in fullscreen views.</div>
     </div>
   }
 </div>

--- a/src/app/components/settings-modal/settings-inputs-tab/mouse-keyer-card/mouse-keyer-card.component.html
+++ b/src/app/components/settings-modal/settings-inputs-tab/mouse-keyer-card/mouse-keyer-card.component.html
@@ -74,6 +74,30 @@
         Mouse clicks are captured in the Morse Decoder area and the fullscreen decoder view.
         Right-click context menu is suppressed when mapped.
       </div>
+
+      <div class="card-section-divider"></div>
+
+      <label>Name:
+        <input type="text" [value]="settings.settings().mouseKeyerName"
+               (input)="onSettingChange('mouseKeyerName', $event)"
+               placeholder="e.g. callsign (optional)"
+               maxlength="20">
+      </label>
+      <div class="keyer-hint">Triggers a line break in conversation views when a different name appears.</div>
+
+      <label>Color:
+        <div class="card-color-row">
+          <input type="color" class="card-color-picker"
+                 [ngModel]="settings.settings().mouseKeyerColor || '#ffffff'"
+                 (ngModelChange)="settings.update({ mouseKeyerColor: $event })">
+          @if (settings.settings().mouseKeyerColor) {
+            <button type="button" class="card-color-clear"
+                    (click)="settings.update({ mouseKeyerColor: '' })" title="Clear color">&#10005;</button>
+          }
+          <span class="card-color-preview" [style.color]="settings.settings().mouseKeyerColor || 'inherit'">Sample</span>
+        </div>
+      </label>
+      <div class="keyer-hint">Optional. Overrides the default RX/TX colour in fullscreen views.</div>
     </div>
   }
 </div>

--- a/src/app/components/settings-modal/settings-inputs-tab/rtdb-input-card/rtdb-input-card.component.html
+++ b/src/app/components/settings-modal/settings-inputs-tab/rtdb-input-card/rtdb-input-card.component.html
@@ -34,14 +34,14 @@
         </select>
       </label>
 
-      <label>Channel Name:
+      <label [class.field-invalid]="!settings.settings().rtdbInputChannelName.trim()">Channel Name<span class="required-mark">*</span>:
         <input type="text" [value]="settings.settings().rtdbInputChannelName"
                (input)="onTextSettingChange('rtdbInputChannelName', $event)"
                placeholder="e.g. cw-practice"
                maxlength="50">
       </label>
 
-      <label>Channel Secret:
+      <label [class.field-invalid]="!settings.settings().rtdbInputChannelSecret.trim()">Channel Secret<span class="required-mark">*</span>:
         <input type="password" [value]="settings.settings().rtdbInputChannelSecret"
                (input)="onTextSettingChange('rtdbInputChannelSecret', $event)"
                placeholder="shared secret"
@@ -69,6 +69,30 @@
         sender's original speed for realistic timing. Enable this option to
         ignore the remote WPM and use your local Encoder WPM instead.
       </div>
+
+      <div class="card-section-divider"></div>
+
+      <label>Override Name:
+        <input type="text" [value]="settings.settings().rtdbInputName"
+               (input)="onSettingChange('rtdbInputName', $event)"
+               placeholder="empty = keep sender's name"
+               maxlength="20">
+      </label>
+      <div class="cw-hint">If set, replaces the incoming sender name. Leave empty to preserve the remote name.</div>
+
+      <label>Override Color:
+        <div class="card-color-row">
+          <input type="color" class="card-color-picker"
+                 [ngModel]="settings.settings().rtdbInputColor || '#ffffff'"
+                 (ngModelChange)="settings.update({ rtdbInputColor: $event })">
+          @if (settings.settings().rtdbInputColor) {
+            <button type="button" class="card-color-clear"
+                    (click)="settings.update({ rtdbInputColor: '' })" title="Clear color">&#10005;</button>
+          }
+          <span class="card-color-preview" [style.color]="settings.settings().rtdbInputColor || 'inherit'">Sample</span>
+        </div>
+      </label>
+      <div class="cw-hint">If set, overrides the incoming colour. Leave cleared to use the sender's colour (or default RX/TX colour).</div>
 
       @if (rtdbService.lastError()) {
         <div class="conflict-warning">{{ rtdbService.lastError() }}</div>

--- a/src/app/components/settings-modal/settings-inputs-tab/rtdb-input-card/rtdb-input-card.component.ts
+++ b/src/app/components/settings-modal/settings-inputs-tab/rtdb-input-card/rtdb-input-card.component.ts
@@ -61,6 +61,14 @@ export class RtdbInputCardComponent implements OnDestroy {
       this.rtdbService.lastError.set('Cannot enable Firebase RTDB input — you are offline.');
       return;
     }
+    if (checked) {
+      const s = this.settings.settings();
+      if (!s.rtdbInputChannelName.trim() || !s.rtdbInputChannelSecret.trim()) {
+        (event.target as HTMLInputElement).checked = false;
+        this.rtdbService.lastError.set('Channel Name and Channel Secret are required to enable RTDB input.');
+        return;
+      }
+    }
     this.settings.update({ rtdbInputEnabled: checked });
     if (checked) {
       this.rtdbService.startInput();
@@ -74,8 +82,15 @@ export class RtdbInputCardComponent implements OnDestroy {
     const value = (event.target as HTMLInputElement).value;
     this.settings.update({ [key]: value } as Partial<AppSettings>);
 
-    const rtdbInputKeys: (keyof AppSettings)[] = ['rtdbInputChannelName', 'rtdbInputChannelSecret'];
-    if (rtdbInputKeys.includes(key) && this.settings.settings().rtdbInputEnabled) {
+    // Auto-disable RTDB input if a required field was cleared
+    const rtdbRequiredKeys: (keyof AppSettings)[] = ['rtdbInputChannelName', 'rtdbInputChannelSecret'];
+    if (rtdbRequiredKeys.includes(key) && this.settings.settings().rtdbInputEnabled && !value.trim()) {
+      this.settings.update({ rtdbInputEnabled: false });
+      this.rtdbService.stopInput();
+      return;
+    }
+
+    if (rtdbRequiredKeys.includes(key) && this.settings.settings().rtdbInputEnabled) {
       if (this.rtdbInputDebounce) clearTimeout(this.rtdbInputDebounce);
       this.rtdbInputDebounce = setTimeout(() => this.rtdbService.startInput(), 600);
     }

--- a/src/app/components/settings-modal/settings-inputs-tab/touch-keyer-card/touch-keyer-card.component.html
+++ b/src/app/components/settings-modal/settings-inputs-tab/touch-keyer-card/touch-keyer-card.component.html
@@ -59,6 +59,30 @@
           </select>
         </label>
       }
+
+      <div class="card-section-divider"></div>
+
+      <label>Name:
+        <input type="text" [value]="settings.settings().touchKeyerName"
+               (input)="onSettingChange('touchKeyerName', $event)"
+               placeholder="e.g. callsign (optional)"
+               maxlength="20">
+      </label>
+      <div class="keyer-hint">Triggers a line break in conversation views when a different name appears.</div>
+
+      <label>Color:
+        <div class="card-color-row">
+          <input type="color" class="card-color-picker"
+                 [ngModel]="settings.settings().touchKeyerColor || '#ffffff'"
+                 (ngModelChange)="settings.update({ touchKeyerColor: $event })">
+          @if (settings.settings().touchKeyerColor) {
+            <button type="button" class="card-color-clear"
+                    (click)="settings.update({ touchKeyerColor: '' })" title="Clear color">&#10005;</button>
+          }
+          <span class="card-color-preview" [style.color]="settings.settings().touchKeyerColor || 'inherit'">Sample</span>
+        </div>
+      </label>
+      <div class="keyer-hint">Optional. Overrides the default RX/TX colour in fullscreen views.</div>
     </div>
   }
 </div>

--- a/src/app/components/settings-modal/settings-outputs-tab/rtdb-output-card/rtdb-output-card.component.html
+++ b/src/app/components/settings-modal/settings-outputs-tab/rtdb-output-card/rtdb-output-card.component.html
@@ -36,26 +36,53 @@
         </div>
       }
 
-      <label>Channel Name:
+      <label [class.field-invalid]="!settings.settings().rtdbOutputChannelName.trim()">Channel Name<span class="required-mark">*</span>:
         <input type="text" [value]="settings.settings().rtdbOutputChannelName"
                (input)="onTextSettingChange('rtdbOutputChannelName', $event)"
                placeholder="e.g. cw-practice"
                maxlength="50">
       </label>
 
-      <label>Channel Secret:
+      <label [class.field-invalid]="!settings.settings().rtdbOutputChannelSecret.trim()">Channel Secret<span class="required-mark">*</span>:
         <input type="password" [value]="settings.settings().rtdbOutputChannelSecret"
                (input)="onTextSettingChange('rtdbOutputChannelSecret', $event)"
                placeholder="shared secret"
                maxlength="50">
       </label>
 
-      <label>Name:
+      <label [class.field-invalid]="!settings.settings().rtdbOutputName.trim()">Name<span class="required-mark">*</span>:
         <input type="text" [value]="settings.settings().rtdbOutputName"
                (input)="onTextSettingChange('rtdbOutputName', $event)"
                placeholder="e.g. callsign"
                maxlength="20">
       </label>
+
+      <label class="checkbox-label">
+        <input type="checkbox" [checked]="settings.settings().rtdbOutputOverrideName"
+               (change)="onBoolChange('rtdbOutputOverrideName', $event)">
+        Always use this name (override input-specific names)
+      </label>
+      <div class="cw-hint">When unchecked, input-specific names (e.g. from Mouse Keyer or CW Detector) are sent if defined; otherwise this name is used as fallback.</div>
+
+      <label>Color:
+        <div class="card-color-row">
+          <input type="color" class="card-color-picker"
+                 [ngModel]="settings.settings().rtdbOutputColor || '#ffffff'"
+                 (ngModelChange)="settings.update({ rtdbOutputColor: $event })">
+          @if (settings.settings().rtdbOutputColor) {
+            <button type="button" class="card-color-clear"
+                    (click)="settings.update({ rtdbOutputColor: '' })" title="Clear color">&#10005;</button>
+          }
+          <span class="card-color-preview" [style.color]="settings.settings().rtdbOutputColor || 'inherit'">Sample</span>
+        </div>
+      </label>
+
+      <label class="checkbox-label">
+        <input type="checkbox" [checked]="settings.settings().rtdbOutputOverrideColor"
+               (change)="onBoolChange('rtdbOutputOverrideColor', $event)">
+        Always use this color (override input-specific colors)
+      </label>
+      <div class="cw-hint">When unchecked, input-specific colors are sent if defined; otherwise this color is used as fallback.</div>
 
       <div class="cw-hint">
         Publishes decoded morse characters to a Firebase Realtime Database channel.
@@ -64,6 +91,9 @@
         <strong>User Name</strong> is attached to each posted letter (typically your
         callsign). Select which decoded text to forward: RX (received), TX
         (transmitted by the encoder/keyer), or both.<br><br>
+        When text is typed via the keyboard encoder, the <strong>Name</strong> and
+        <strong>Color</strong> defined here are always used (the encoder has no
+        input-specific tagging).<br><br>
         Only the <strong>last letter</strong> per channel is stored &mdash; no message
         history is retained. Channel limits and automatic expiry are configured
         externally via Firebase Security Rules and Cloud Functions.<br><br>

--- a/src/app/components/settings-modal/settings-outputs-tab/rtdb-output-card/rtdb-output-card.component.ts
+++ b/src/app/components/settings-modal/settings-outputs-tab/rtdb-output-card/rtdb-output-card.component.ts
@@ -47,6 +47,12 @@ export class RtdbOutputCardComponent implements OnDestroy {
     this.settings.update({ [key]: value } as Partial<AppSettings>);
   }
 
+  /** Handle a boolean setting change from a checkbox */
+  onBoolChange(key: keyof AppSettings, event: Event): void {
+    const checked = (event.target as HTMLInputElement).checked;
+    this.settings.update({ [key]: checked } as Partial<AppSettings>);
+  }
+
   /** Handle RTDB output enabled toggle — starts/stops the RTDB publisher */
   onRtdbOutputEnabledChange(event: Event): void {
     const checked = (event.target as HTMLInputElement).checked;
@@ -54,6 +60,14 @@ export class RtdbOutputCardComponent implements OnDestroy {
       (event.target as HTMLInputElement).checked = false;
       this.rtdbService.lastError.set('Cannot enable Firebase RTDB output — you are offline.');
       return;
+    }
+    if (checked) {
+      const s = this.settings.settings();
+      if (!s.rtdbOutputChannelName.trim() || !s.rtdbOutputChannelSecret.trim() || !s.rtdbOutputName.trim()) {
+        (event.target as HTMLInputElement).checked = false;
+        this.rtdbService.lastError.set('Channel Name, Channel Secret, and Name are required to enable RTDB output.');
+        return;
+      }
     }
     this.settings.update({ rtdbOutputEnabled: checked });
     if (checked) {
@@ -70,6 +84,14 @@ export class RtdbOutputCardComponent implements OnDestroy {
   onTextSettingChange(key: keyof AppSettings, event: Event): void {
     const value = (event.target as HTMLInputElement).value;
     this.settings.update({ [key]: value } as Partial<AppSettings>);
+
+    // Auto-disable RTDB output if a required field was cleared
+    const rtdbRequiredKeys: (keyof AppSettings)[] = ['rtdbOutputChannelName', 'rtdbOutputChannelSecret', 'rtdbOutputName'];
+    if (rtdbRequiredKeys.includes(key) && this.settings.settings().rtdbOutputEnabled && !value.trim()) {
+      this.settings.update({ rtdbOutputEnabled: false });
+      this.rtdbService.stopOutput();
+      return;
+    }
 
     const rtdbOutputKeys: (keyof AppSettings)[] = ['rtdbOutputChannelName', 'rtdbOutputChannelSecret', 'rtdbOutputName'];
     if (rtdbOutputKeys.includes(key) && this.settings.settings().rtdbOutputEnabled) {

--- a/src/app/components/settings-modal/settings-shared.css
+++ b/src/app/components/settings-modal/settings-shared.css
@@ -626,6 +626,53 @@
   cursor: pointer;
 }
 
+/* ---- Name / colour tag fields (card-level) ---- */
+.card-color-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+.card-color-picker {
+  width: 36px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid #444;
+  border-radius: 4px;
+  cursor: pointer;
+  background: transparent;
+}
+.card-color-clear {
+  background: transparent;
+  color: #888;
+  border: 1px solid #444;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0.15rem 0.4rem;
+  line-height: 1;
+}
+.card-color-clear:hover {
+  color: #ccc;
+  border-color: #666;
+}
+.card-color-preview {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+/* ---- Mandatory field indicators ---- */
+.required-mark {
+  color: #e55;
+  margin-left: 0.15em;
+}
+.field-invalid {
+  color: #e55;
+}
+.field-invalid input[type="text"],
+.field-invalid input[type="password"] {
+  border-color: #c44;
+}
+
 /* Shared button styles — scoped to settings cards to avoid leaking globally */
 .settings-card-body button {
   cursor: pointer;

--- a/src/app/services/firebase-rtdb.service.ts
+++ b/src/app/services/firebase-rtdb.service.ts
@@ -38,6 +38,8 @@ interface RtdbLetterEntry {
   ts: object | number;
   /** WPM speed used to generate this character (2-digit number) */
   wpm?: number;
+  /** Optional text color (CSS color string) for fullscreen display */
+  col?: string;
 }
 
 /**
@@ -81,7 +83,7 @@ export class FirebaseRtdbService implements OnDestroy {
   readonly connectionWarning = signal<string | null>(null);
 
   /** Emits received characters from the subscribed input channel */
-  readonly incomingChar$ = new Subject<{ char: string; source: 'rx' | 'tx'; name: string; wpm: number }>();
+  readonly incomingChar$ = new Subject<{ char: string; source: 'rx' | 'tx'; name: string; wpm: number; color?: string }>();
 
   /** Whether we are actively listening to an input channel */
   readonly inputListening = signal(false);
@@ -95,6 +97,9 @@ export class FirebaseRtdbService implements OnDestroy {
   private inputRef: DatabaseReference | null = null;
   private lastInputChar: string | null = null;
   private lastInputTs: number = 0;
+
+  /** Names we have sent via RTDB output — used for echo suppression */
+  private sentNames = new Set<string>();
 
   // ── Server-time synchronisation ──
   /**
@@ -341,10 +346,10 @@ export class FirebaseRtdbService implements OnDestroy {
           }
         }
 
-        // Skip our own echoes: if the incoming name matches our output
-        // name, this is a character we wrote — don't feed it back.
-        const ourName = this.settings.settings().rtdbOutputName.trim();
-        if (ourName && data.name === ourName) return;
+        // Skip our own echoes: if the incoming name matches any name
+        // we have sent (rtdbOutputName or any input-specific name),
+        // this is a character we wrote — don't feed it back.
+        if (data.name && this.sentNames.has(data.name)) return;
 
         this.lastInputChar = data.char;
         this.lastInputTs = ts;
@@ -354,7 +359,7 @@ export class FirebaseRtdbService implements OnDestroy {
         const wpm = (typeof data.wpm === 'number' && data.wpm >= 5 && data.wpm <= 60)
           ? data.wpm
           : this.settings.settings().encoderWpm;
-        this.incomingChar$.next({ char: data.char, source, name: data.name || '', wpm });
+        this.incomingChar$.next({ char: data.char, source, name: data.name || '', wpm, color: data.col || undefined });
       });
     }, (err) => {
       this.zone.run(() => {
@@ -420,6 +425,7 @@ export class FirebaseRtdbService implements OnDestroy {
     if (this.outputRetryTimer) { clearTimeout(this.outputRetryTimer); this.outputRetryTimer = null; }
     this.outputRetries = 0;
     this.outputActive.set(false);
+    this.sentNames.clear();
   }
 
   // ──────────────────────────────────────────────
@@ -528,7 +534,7 @@ export class FirebaseRtdbService implements OnDestroy {
    * @param source Whether this came from 'rx' or 'tx' decoder pool
    * @param wpm    WPM speed used to generate this character
    */
-  async forwardDecodedChar(char: string, source: 'rx' | 'tx', wpm?: number): Promise<void> {
+  async forwardDecodedChar(char: string, source: 'rx' | 'tx', wpm?: number, inputName?: string, inputColor?: string): Promise<void> {
     if (!this.settings.settings().rtdbOutputEnabled) return;
     if (!this.outputActive()) return;
     if (!this.db) return;
@@ -540,7 +546,20 @@ export class FirebaseRtdbService implements OnDestroy {
 
     const channelName = s.rtdbOutputChannelName.trim();
     const channelSecret = s.rtdbOutputChannelSecret.trim();
-    const name = s.rtdbOutputName.trim();
+    const rtdbName = s.rtdbOutputName.trim();
+
+    // Determine effective name: override checkbox forces rtdbOutputName;
+    // otherwise prefer input-specific name, fall back to rtdbOutputName.
+    const effectiveName = s.rtdbOutputOverrideName
+      ? (rtdbName || 'Anonymous')
+      : (inputName?.trim() || rtdbName || 'Anonymous');
+
+    // Determine effective color: override checkbox forces rtdbOutputColor;
+    // otherwise prefer input-specific color, fall back to rtdbOutputColor.
+    const rtdbColor = s.rtdbOutputColor.trim();
+    const effectiveColor = s.rtdbOutputOverrideColor
+      ? rtdbColor
+      : (inputColor?.trim() || rtdbColor);
 
     if (!channelName || !channelSecret) return;
 
@@ -548,12 +567,16 @@ export class FirebaseRtdbService implements OnDestroy {
     const entryRef = ref(this.db, path);
 
     try {
-      await set(entryRef, {
+      const entry: Record<string, unknown> = {
         char,
-        name: name || 'Anonymous',
+        name: effectiveName,
         ts: serverTimestamp(),
         wpm: wpm ?? s.encoderWpm,
-      });
+      };
+      if (effectiveColor) entry['col'] = effectiveColor;
+      // Track the name before writing — onValue fires synchronously on local set()
+      this.sentNames.add(effectiveName);
+      await set(entryRef, entry);
     } catch (err: any) {
       // Don't spam errors for every character — just set once
       if (!this.lastError()) {

--- a/src/app/services/mouse-keyer.service.ts
+++ b/src/app/services/mouse-keyer.service.ts
@@ -118,15 +118,16 @@ export class MouseKeyerService implements OnDestroy {
     const s = this.settings.settings();
     const reverse = s.mouseReversePaddles;
     const source = s.mouseKeyerSource;
+    const opts = { name: s.mouseKeyerName || undefined, color: s.mouseKeyerColor || undefined };
     switch (action) {
       case 'straightKey':
-        this.keyer.straightKeyInput(down, source, false, 'mouseStraightKey');
+        this.keyer.straightKeyInput(down, source, false, 'mouseStraightKey', opts);
         break;
       case 'dit':
-        if (reverse) this.keyer.dahPaddleInput(down, source, false, 'mousePaddle', s.mousePaddleMode); else this.keyer.ditPaddleInput(down, source, false, 'mousePaddle', s.mousePaddleMode);
+        if (reverse) this.keyer.dahPaddleInput(down, source, false, 'mousePaddle', s.mousePaddleMode, opts); else this.keyer.ditPaddleInput(down, source, false, 'mousePaddle', s.mousePaddleMode, opts);
         break;
       case 'dah':
-        if (reverse) this.keyer.ditPaddleInput(down, source, false, 'mousePaddle', s.mousePaddleMode); else this.keyer.dahPaddleInput(down, source, false, 'mousePaddle', s.mousePaddleMode);
+        if (reverse) this.keyer.ditPaddleInput(down, source, false, 'mousePaddle', s.mousePaddleMode, opts); else this.keyer.dahPaddleInput(down, source, false, 'mousePaddle', s.mousePaddleMode, opts);
         break;
     }
   }

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -208,6 +208,10 @@ export interface AppSettings {
   micInputEnabled: boolean;
   /** Decoder source: which calibration pool mic input feeds ('rx' or 'tx') */
   micInputSource: DecoderSource;
+  /** Optional display name (e.g. callsign) — triggers line breaks in conversation views */
+  micInputName: string;
+  /** Optional text color (CSS color string) — overrides RX/TX default in fullscreen views */
+  micInputColor: string;
   inputDeviceId: string;
   inputThreshold: number;
   inputInvert: boolean;
@@ -230,6 +234,10 @@ export interface AppSettings {
   cwInputDebounceMs: number;
   cwInputAutoThreshold: boolean;
   cwInputThreshold: number;
+  /** Optional display name (e.g. callsign) — triggers line breaks in conversation views */
+  cwInputName: string;
+  /** Optional text color (CSS color string) — overrides RX/TX default in fullscreen views */
+  cwInputColor: string;
 
   // --- 2. Key Output via Audio Channel (opto-coupler) ---
   optoOutputDeviceId: string;
@@ -262,6 +270,12 @@ export interface AppSettings {
   rtdbOutputChannelName: string;
   rtdbOutputChannelSecret: string;
   rtdbOutputName: string;
+  /** Optional text color (CSS color string) — sent as 'col' parameter to remote listeners */
+  rtdbOutputColor: string;
+  /** When true, always send rtdbOutputName — overriding any input-specific name */
+  rtdbOutputOverrideName: boolean;
+  /** When true, always send rtdbOutputColor — overriding any input-specific color */
+  rtdbOutputOverrideColor: boolean;
 
   // --- 3. Audio Output (sidetone / headphone / speaker) ---
   sidetoneOutputDeviceId: string;
@@ -305,6 +319,10 @@ export interface AppSettings {
   mouseRightAction: MouseButtonAction;
   mouseReversePaddles: boolean;
   mousePaddleMode: PaddleMode;
+  /** Optional display name (e.g. callsign) — triggers line breaks in conversation views */
+  mouseKeyerName: string;
+  /** Optional text color (CSS color string) — overrides RX/TX default in fullscreen views */
+  mouseKeyerColor: string;
 
   // --- Touch Keyer ---
   touchKeyerEnabled: boolean;
@@ -315,6 +333,10 @@ export interface AppSettings {
   touchRightPaddle: PaddleElement;
   touchReversePaddles: boolean;
   touchPaddleMode: PaddleMode;
+  /** Optional display name (e.g. callsign) — triggers line breaks in conversation views */
+  touchKeyerName: string;
+  /** Optional text color (CSS color string) — overrides RX/TX default in fullscreen views */
+  touchKeyerColor: string;
 
   // --- MIDI Input ---
   midiInputEnabled: boolean;
@@ -335,6 +357,10 @@ export interface AppSettings {
   rtdbInputChannelSecret: string;
   /** When true, ignore remote WPM and use local encoder WPM for playback */
   rtdbInputOverrideWpm: boolean;
+  /** Optional override name — if non-empty, replaces the incoming sender name */
+  rtdbInputName: string;
+  /** Optional override color — if non-empty, replaces the incoming sender color */
+  rtdbInputColor: string;
 
   // --- Sprite Key Button ---
   /** Show the straight-key sprite button on the main screen */
@@ -395,6 +421,8 @@ const DEVICE_SETTINGS_KEYS: (keyof AppSettings)[] = [
 const DEFAULT_SETTINGS: AppSettings = {
   micInputEnabled: false,
   micInputSource: 'rx',
+  micInputName: '',
+  micInputColor: '',
   inputDeviceId: 'default',
   inputThreshold: 0.01,
   inputInvert: false,
@@ -414,6 +442,8 @@ const DEFAULT_SETTINGS: AppSettings = {
   cwInputDebounceMs: 10,
   cwInputAutoThreshold: true,
   cwInputThreshold: 0.01,
+  cwInputName: '',
+  cwInputColor: '',
 
   optoOutputDeviceId: 'default',
   optoOutputChannel: 'right',
@@ -478,6 +508,9 @@ const DEFAULT_SETTINGS: AppSettings = {
   rtdbOutputChannelName: '',
   rtdbOutputChannelSecret: '',
   rtdbOutputName: '',
+  rtdbOutputColor: '',
+  rtdbOutputOverrideName: false,
+  rtdbOutputOverrideColor: false,
 
   sidetoneOutputDeviceId: 'default',
   sidetoneOutputChannel: 'left',
@@ -542,6 +575,8 @@ const DEFAULT_SETTINGS: AppSettings = {
   mouseRightAction: 'none',
   mouseReversePaddles: false,
   mousePaddleMode: 'iambic-b',
+  mouseKeyerName: '',
+  mouseKeyerColor: '',
 
   touchKeyerEnabled: isTouchDevice(),
   touchKeyerSource: 'tx',
@@ -550,6 +585,8 @@ const DEFAULT_SETTINGS: AppSettings = {
   touchRightPaddle: 'dah',
   touchReversePaddles: false,
   touchPaddleMode: 'iambic-b',
+  touchKeyerName: '',
+  touchKeyerColor: '',
 
   midiInputEnabled: false,
   midiInputMappings: [
@@ -607,6 +644,8 @@ const DEFAULT_SETTINGS: AppSettings = {
   rtdbInputChannelName: '',
   rtdbInputChannelSecret: '',
   rtdbInputOverrideWpm: false,
+  rtdbInputName: '',
+  rtdbInputColor: '',
 
   spriteButtonEnabled: true,
   spriteAnimateKeyboard: false,

--- a/src/app/version.ts
+++ b/src/app/version.ts
@@ -1,2 +1,2 @@
 /** Single source of truth for the application version displayed in the UI. */
-export const APP_VERSION = '1.3.0';
+export const APP_VERSION = '1.4.0';


### PR DESCRIPTION
## Description

- **Input Name & Colour Tagging** — Mouse Keyer, Touch Keyer, CW Tone
  Detector, and Straight Key via Mic now support optional **Name** and
  **Colour** fields, matching the existing pattern in Keyboard, MIDI, and
  Serial inputs. When a name is set, switching between inputs triggers a
  line break in conversation views. Colour overrides the default RX/TX
  colour in fullscreen views.
- **Firebase RTDB Output Colour** — RTDB output can now optionally send a
  colour (`col` parameter) alongside each character. Remote listeners
  display this colour in their fullscreen views.

## Related Issue

Closes #4

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] My code follows the existing code style of the project
- [X] The app builds without errors (`ng build`)
- [X] I have tested my changes in Chrome or Edge
- [X] I have added/updated documentation as needed

