### PR TITLE
v1.5.0 text blurring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-03-14
+
+### Added
+
+- **Text Blurring (Training Mode)** — New setting under Settings → Other that
+  blurs decoded text so you can practice reading Morse by ear without
+  accidentally seeing the answer. Configurable to blur RX only, TX only, or
+  both directions. A floating eye button in the text area acts as a momentary
+  reveal switch — press and hold to unblur with a 250 ms animated transition.
+  Works in both the main screen parchment view and fullscreen decoder/encoder
+  views. Name tags remain visible; only the text content is blurred. Text
+  colour is preserved through the blur effect.
+- **Inline Port Granting** — All serial port dropdowns (WinKeyer, Serial Input
+  edit modal, Serial Output edit modal) now include a `+ Add serial port…`
+  option directly in the select box. Selecting it opens the browser's port
+  permission dialog without needing to navigate to a different service's
+  settings first.
+
+### Changed
+
+- **WinKeyer Port Selection** — Removed the separate "Add Serial Port" and
+  "Refresh" buttons. Port list auto-refreshes when the card is expanded.
+  Port granting is now inline via the dropdown's `+ Add serial port…` option.
+- **WinKeyer Auto-Connect** — WinKeyer now auto-connects on page load when
+  previously enabled (matching the serial output service's behaviour) and
+  retries with increasing delays (0, 500, 1500, 3000 ms) to handle late
+  USB enumeration.
+- **WinKeyer Reconnect on Replug** — Fixed reconnection when unplugging and
+  replugging the USB cable. The service now properly closes stale connections
+  before reconnecting and uses the same retry-with-backoff strategy as the
+  serial output service.
+- **Serial Reconnect VID/PID Matching** — WinKeyer and serial output
+  services now remember each port's USB VID/PID on connection. When a port
+  reappears at a different index after re-plug, the app finds it by VID/PID
+  and updates the stored index automatically. Note: whether the browser
+  remembers a previously granted port after disconnect depends on the
+  device's USB descriptor; some budget USB-serial chipsets without unique
+  serial numbers may require re-granting the port via the
+  `+ Add serial port…` dropdown option.
+
 ## [1.4.0] - 2026-03-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Common adapters (FTDI FT232R, CH340, CP2102, PL2303) are supported. Works with a
 
 ### WinKeyer
 
-For stations using a K1EL WinKeyer (WK2/WK3/WKUSB), the app can forward decoded or encoded text to the WinKeyer over its serial port. The WinKeyer generates hardware-precision CW keying independently — useful for relay, practice, or driving an external transmitter.
+For stations using a K1EL WinKeyer (WK2/WK3/WKUSB), the app can forward decoded or encoded text to the WinKeyer over its serial port. The WinKeyer generates hardware-precision CW keying independently — useful for relay, practice, or driving an external transmitter. The connection is established automatically on page load and the app attempts to reconnect when a USB device is unplugged and reconnected. Whether the browser remembers a previously granted port after re-plug depends on the device and browser — devices with a unique USB serial number (e.g. genuine FTDI adapters) are reliably matched, while some budget chipsets may require re-granting the port.
 
 ### Sound Card (Experimental)
 
@@ -66,6 +66,7 @@ Every output (optocoupler, serial port, WinKeyer, sidetone, vibration, Firebase 
 
 ## Additional Features
 
+- **Text Blurring** — Hides decoded and/or encoded text behind a blur filter for copy-receiving practice. Configurable for RX only, TX only, or both. Press and hold the eye button to momentarily reveal the answer.
 - **Haptic Vibration** — The device vibrates in sync with the sidetone while the key is down. Configurable for TX only, RX only, or both. Enhanced haptic timing compensates for Android motor spin-up latency. Android only (Chrome, Firefox, Edge).
 - **Screen Wake Lock** — Prevents the screen from locking during operation. Important on mobile where screen lock suspends network connectivity, interrupting Firebase relay. Uses the Screen Wake Lock API (Chrome 84+, Edge 84+, Safari 16.4+).
 - **Progressive Web App** — Installable as a standalone app on desktop (Chrome, Edge) and mobile (Android Chrome, iOS Safari). The Angular service worker caches the app shell and assets for offline access.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "morse-code-studio",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "morse-code-studio",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@angular/animations": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morse-code-studio",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A browser-based Morse code encoder, decoder and keyer built with Angular and the Web Audio API",
   "author": "5B4AON — Mike",
   "repository": {

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -543,6 +543,60 @@
   opacity: .6;
   font-weight: 600;
 }
+
+/* ===== Text Blurring (training mode) ===== */
+.decoded-text .line-text {
+  transition: filter 250ms ease;
+}
+.decoded-text.blur-rx .rx-line .line-text,
+.decoded-text.blur-tx .tx-line .line-text,
+.decoded-text.blur-both .rx-line .line-text,
+.decoded-text.blur-both .tx-line .line-text {
+  filter: blur(5px);
+}
+.decoded-text.blur-revealing .rx-line .line-text,
+.decoded-text.blur-revealing .tx-line .line-text {
+  filter: blur(0) !important;
+}
+
+/* Reveal button — parchment-themed */
+.blur-reveal-btn-main {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(160, 140, 110, 0.7);
+  border: 1px solid rgba(120, 100, 70, 0.5);
+  color: rgba(60, 45, 30, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 5;
+  padding: 0;
+  min-height: unset;
+  box-shadow: 0 1px 4px rgba(80, 60, 40, 0.25);
+  transition: background 0.15s, color 0.15s;
+  touch-action: manipulation;
+  -webkit-user-select: none;
+  user-select: none;
+}
+.blur-reveal-btn-main:hover {
+  background: rgba(170, 150, 120, 0.85);
+  color: rgba(50, 35, 20, 0.9);
+}
+.blur-reveal-btn-main:active,
+.blur-reveal-btn-main.revealing {
+  background: rgba(140, 120, 90, 0.9);
+  color: #2a1e12;
+}
+.blur-reveal-btn-main svg {
+  display: block;
+  pointer-events: none;
+}
+
 .decoded-actions {
   display: flex;
   align-items: center;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -161,7 +161,27 @@
     }
 
     <div class="decoded-parchment">
-      <div class="decoded-text" #decoderBox>{{ displayBuffers.mainOutput.text() }}<span class="cursor">{{ decoder.currentPattern() }}</span></div>
+      <div class="decoded-text" #decoderBox
+           [class.blur-rx]="mainBlurMode === 'rx'" [class.blur-tx]="mainBlurMode === 'tx'" [class.blur-both]="mainBlurMode === 'both'"
+           [class.blur-revealing]="mainRevealing">@for (line of displayBuffers.mainOutput.lines(); track $index) {<span
+             [class.rx-line]="line.type === 'rx'"
+             [class.tx-line]="line.type === 'tx'">{{ mainLinePrefix($index) }}<span class="line-text">{{ line.text }}</span></span>}<span class="cursor">{{ decoder.currentPattern() }}</span></div>
+      @if (mainBlurMode) {
+        <button class="blur-reveal-btn-main" [class.revealing]="mainRevealing"
+                (mousedown)="onMainRevealStart($event)"
+                (mouseup)="onMainRevealEnd()"
+                (mouseleave)="onMainRevealEnd()"
+                (touchstart)="onMainRevealStart($event)"
+                (touchend)="onMainRevealEnd()"
+                (touchcancel)="onMainRevealEnd()"
+                title="Hold to reveal text">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor"
+               stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+            <circle cx="12" cy="12" r="3"/>
+          </svg>
+        </button>
+      }
     </div>
     @if (settings.settings().cwInputEnabled) {
       <div class="decoded-actions">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -135,6 +135,10 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
    */
   midiInputNeedsReconnect = false;
   midiOutputNeedsReconnect = false;
+
+  /** Whether the main screen blurred text is being revealed (button held) */
+  mainRevealing = false;
+
   constructor(
     private hostRef: ElementRef,
     public settings: SettingsService,
@@ -158,7 +162,7 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
   ) {
     // Auto-scroll the main decoder box when new text arrives
     effect(() => {
-      this.displayBuffers.mainOutput.text();
+      this.displayBuffers.mainOutput.lines();
       const el = this.decoderBoxRef?.nativeElement;
       if (el) {
         requestAnimationFrame(() => el.scrollTop = el.scrollHeight);
@@ -694,6 +698,48 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
     this.displayBuffers.clearAll();
     this.decoder.clearOutput();
     this.encoder.clearBuffer();
+  }
+
+  // ---- Text blur ----
+
+  /**
+   * Active blur mode for the main screen.
+   * Returns null when blur is disabled, otherwise the appliesTo value.
+   */
+  get mainBlurMode(): 'rx' | 'tx' | 'both' | null {
+    const s = this.settings.settings();
+    return s.textBlurEnabled ? s.textBlurAppliesTo : null;
+  }
+
+  /**
+   * Returns a newline prefix when the line at this index starts a new
+   * type/name segment — replicating the conversation-style line breaks
+   * that the flat text() signal normally provides.
+   */
+  mainLinePrefix(index: number): string {
+    if (index === 0) return '';
+    const lines = this.displayBuffers.mainOutput.lines();
+    const prev = lines[index - 1];
+    const curr = lines[index];
+    if (curr.type !== prev.type || curr.name !== prev.name) {
+      // Match the newline logic: only if the current line text doesn't
+      // already start with \n and the previous doesn't end with \n
+      if (!curr.text.startsWith('\n') && !prev.text.endsWith('\n')) {
+        return '\n';
+      }
+    }
+    return '';
+  }
+
+  /** Start revealing blurred text on main screen (momentary hold) */
+  onMainRevealStart(event: Event): void {
+    event.preventDefault();
+    this.mainRevealing = true;
+  }
+
+  /** Stop revealing blurred text on main screen */
+  onMainRevealEnd(): void {
+    this.mainRevealing = false;
   }
 
   toggleClearMenu(): void {

--- a/src/app/components/fullscreen-modal/fs-decoder-view/fs-decoder-view.component.css
+++ b/src/app/components/fullscreen-modal/fs-decoder-view/fs-decoder-view.component.css
@@ -55,3 +55,8 @@
   margin-top: 4px;
   opacity: 0.7;
 }
+
+/* Shift reveal button above touch overlay when touch keyer is active */
+.blur-reveal-above-touch {
+  bottom: 106px;
+}

--- a/src/app/components/fullscreen-modal/fs-decoder-view/fs-decoder-view.component.html
+++ b/src/app/components/fullscreen-modal/fs-decoder-view/fs-decoder-view.component.html
@@ -1,9 +1,12 @@
 <!-- Decoder: live decoded text conversation area -->
-<div class="fs-conversation" [class.vk-open]="viewportKeyboardOpen" #conversationArea>
+<div class="fs-conversation" [class.vk-open]="viewportKeyboardOpen"
+     [class.blur-rx]="blurMode === 'rx'" [class.blur-tx]="blurMode === 'tx'" [class.blur-both]="blurMode === 'both'"
+     [class.blur-revealing]="revealing" #conversationArea>
   @for (line of conversationLines; track $index) {
     @if ($last) {
       <!-- Last line: show text inline, then same-source pattern cursor -->
       <span class="fs-line fs-line-inline"
+            [class.rx-line]="line.type === 'rx'" [class.tx-line]="line.type === 'tx'"
             [style.marginBottom.em]="settings.modalDisplay().lineSpacing"
             [style.color]="line.color || (line.type === 'rx' ? settings.modalDisplay().rxForeground : settings.modalDisplay().txForeground)"
             [innerHTML]="formatLine(line)"></span><span class="cursor"
@@ -18,6 +21,7 @@
       }
     } @else {
       <div class="fs-line"
+           [class.rx-line]="line.type === 'rx'" [class.tx-line]="line.type === 'tx'"
            [style.marginBottom.em]="settings.modalDisplay().lineSpacing"
            [style.color]="line.color || (line.type === 'rx' ? settings.modalDisplay().rxForeground : settings.modalDisplay().txForeground)"
            [innerHTML]="formatLine(line)"></div>
@@ -37,6 +41,25 @@
     }
   }
 </div>
+
+<!-- Blur reveal button (momentary hold to unblur) -->
+@if (blurMode) {
+  <button class="blur-reveal-btn" [class.revealing]="revealing"
+          [class.blur-reveal-above-touch]="settings.settings().touchKeyerEnabled"
+          (mousedown)="onRevealStart($event)"
+          (mouseup)="onRevealEnd()"
+          (mouseleave)="onRevealEnd()"
+          (touchstart)="onRevealStart($event)"
+          (touchend)="onRevealEnd()"
+          (touchcancel)="onRevealEnd()"
+          title="Hold to reveal text">
+    <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor"
+         stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+      <circle cx="12" cy="12" r="3"/>
+    </svg>
+  </button>
+}
 
 <!-- Touch keyer overlay (decoder mode only) -->
 @if (settings.settings().touchKeyerEnabled) {

--- a/src/app/components/fullscreen-modal/fs-decoder-view/fs-decoder-view.component.ts
+++ b/src/app/components/fullscreen-modal/fs-decoder-view/fs-decoder-view.component.ts
@@ -49,6 +49,9 @@ export class FsDecoderViewComponent implements OnInit, OnDestroy, OnChanges, Aft
   private needsScroll = false;
   private mouseAttached = false;
 
+  /** Whether text is currently being revealed (button held) */
+  revealing = false;
+
   constructor(
     public settings: SettingsService,
     public decoder: MorseDecoderService,
@@ -59,11 +62,31 @@ export class FsDecoderViewComponent implements OnInit, OnDestroy, OnChanges, Aft
   ) {}
 
   /**
+   * Active blur mode derived from settings.
+   * Returns null when blur is disabled, otherwise the appliesTo value.
+   */
+  get blurMode(): 'rx' | 'tx' | 'both' | null {
+    const s = this.settings.settings();
+    return s.textBlurEnabled ? s.textBlurAppliesTo : null;
+  }
+
+  /**
    * Conversation lines from the fullscreen decoder display buffer.
    * Accumulates continuously in the root-provided DisplayBufferService.
    */
   get conversationLines(): DisplayLine[] {
     return this.displayBuffers.fullscreenDecoder.lines();
+  }
+
+  /** Start revealing blurred text (momentary hold) */
+  onRevealStart(event: Event): void {
+    event.preventDefault();
+    this.revealing = true;
+  }
+
+  /** Stop revealing blurred text */
+  onRevealEnd(): void {
+    this.revealing = false;
   }
 
   ngOnInit(): void {

--- a/src/app/components/fullscreen-modal/fs-encoder-view/fs-encoder-view.component.css
+++ b/src/app/components/fullscreen-modal/fs-encoder-view/fs-encoder-view.component.css
@@ -67,3 +67,8 @@
 .vk-toggle-btn svg {
   display: block;
 }
+
+/* Shift reveal button left of the VK toggle when touch input is present */
+.blur-reveal-beside-vk {
+  right: 76px;
+}

--- a/src/app/components/fullscreen-modal/fs-encoder-view/fs-encoder-view.component.html
+++ b/src/app/components/fullscreen-modal/fs-encoder-view/fs-encoder-view.component.html
@@ -1,10 +1,12 @@
 <!-- Encoder mode: conversation + inline encoder buffer -->
-<div class="fs-conversation" [class.vk-open]="viewportKeyboardOpen" #conversationArea
+<div class="fs-conversation" [class.vk-open]="viewportKeyboardOpen"
+     [class.blur-rx]="blurMode === 'rx'" [class.blur-tx]="blurMode === 'tx'" [class.blur-both]="blurMode === 'both'"
+     [class.blur-revealing]="revealing" #conversationArea
      tabindex="0" (keydown)="onEncoderModalKeydown($event)">
   @for (line of conversationLines; track $index) {
     @if ($last && line.type === 'rx') {
       <!-- RX last line: RX pattern inline, encoder buffer on new line -->
-      <span class="fs-line fs-line-inline"
+      <span class="fs-line fs-line-inline rx-line"
             [style.marginBottom.em]="settings.modalDisplay().lineSpacing"
             [style.color]="line.color || settings.modalDisplay().rxForeground"
             [innerHTML]="formatLine(line)"></span><span class="cursor"
@@ -23,7 +25,7 @@
       }
     } @else if ($last && line.type === 'tx') {
       <!-- TX last line: encoder buffer inline, then pattern cursors -->
-      <span class="fs-line fs-line-inline"
+      <span class="fs-line fs-line-inline tx-line"
             [style.marginBottom.em]="settings.modalDisplay().lineSpacing"
             [style.color]="line.color || settings.modalDisplay().txForeground"
             [innerHTML]="formatLine(line)"></span>@if (encoderPendingChars().length) {<span class="fs-encoder-inline">@for (char of encoderPendingChars(); track $index) {<span
@@ -40,6 +42,7 @@
     } @else {
       <!-- Non-last line: block -->
       <div class="fs-line"
+           [class.rx-line]="line.type === 'rx'" [class.tx-line]="line.type === 'tx'"
            [style.marginBottom.em]="settings.modalDisplay().lineSpacing"
            [style.color]="line.color || (line.type === 'rx' ? settings.modalDisplay().rxForeground : settings.modalDisplay().txForeground)"
            [innerHTML]="formatLine(line)"></div>
@@ -70,6 +73,25 @@
     }
   }
 </div>
+
+<!-- Blur reveal button (momentary hold to unblur) -->
+@if (blurMode) {
+  <button class="blur-reveal-btn" [class.revealing]="revealing"
+          [class.blur-reveal-beside-vk]="hasTouchInput"
+          (mousedown)="onRevealStart($event)"
+          (mouseup)="onRevealEnd()"
+          (mouseleave)="onRevealEnd()"
+          (touchstart)="onRevealStart($event)"
+          (touchend)="onRevealEnd()"
+          (touchcancel)="onRevealEnd()"
+          title="Hold to reveal text">
+    <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor"
+         stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+      <circle cx="12" cy="12" r="3"/>
+    </svg>
+  </button>
+}
 
 <!-- Virtual keyboard support for touch/mobile devices -->
 @if (hasTouchInput) {

--- a/src/app/components/fullscreen-modal/fs-encoder-view/fs-encoder-view.component.ts
+++ b/src/app/components/fullscreen-modal/fs-encoder-view/fs-encoder-view.component.ts
@@ -45,10 +45,14 @@ export class FsEncoderViewComponent implements OnInit, OnDestroy, OnChanges, Aft
   @ViewChild('virtualKeyInput') virtualKeyInputRef?: ElementRef<HTMLInputElement>;
 
   /** Whether touch input is available (shows virtual keyboard toggle) */
+  /** Whether touch input is available (shows virtual keyboard toggle) */
   hasTouchInput = false;
 
   /** Whether the on-screen virtual keyboard is currently visible */
   virtualKeyboardVisible = false;
+
+  /** Whether text is currently being revealed (button held) */
+  revealing = false;
 
   /** Last known scrollHeight — used to detect content changes for auto-scroll */
   private lastScrollHeight = 0;
@@ -78,11 +82,31 @@ export class FsEncoderViewComponent implements OnInit, OnDestroy, OnChanges, Aft
   ) {}
 
   /**
+   * Active blur mode derived from settings.
+   * Returns null when blur is disabled, otherwise the appliesTo value.
+   */
+  get blurMode(): 'rx' | 'tx' | 'both' | null {
+    const s = this.settings.settings();
+    return s.textBlurEnabled ? s.textBlurAppliesTo : null;
+  }
+
+  /**
    * Conversation lines from the fullscreen encoder display buffer.
    * Accumulates continuously in the root-provided DisplayBufferService.
    */
   get conversationLines(): DisplayLine[] {
     return this.displayBuffers.fullscreenEncoder.lines();
+  }
+
+  /** Start revealing blurred text (momentary hold) */
+  onRevealStart(event: Event): void {
+    event.preventDefault();
+    this.revealing = true;
+  }
+
+  /** Stop revealing blurred text */
+  onRevealEnd(): void {
+    this.revealing = false;
   }
 
   ngOnInit(): void {

--- a/src/app/components/fullscreen-modal/fullscreen-format.utils.ts
+++ b/src/app/components/fullscreen-modal/fullscreen-format.utils.ts
@@ -173,6 +173,6 @@ export function formatLine(line: DisplayLine, settings: AppSettings, sanitizer: 
   if (line.name) {
     result += `<span class="rtdb-user-prefix">[${escapeHtml(line.name)}] </span>`;
   }
-  result += formatTextInternal(line.text, settings);
+  result += `<span class="line-text">${formatTextInternal(line.text, settings)}</span>`;
   return sanitizer.bypassSecurityTrustHtml(result);
 }

--- a/src/app/components/fullscreen-modal/fullscreen-shared.css
+++ b/src/app/components/fullscreen-modal/fullscreen-shared.css
@@ -89,3 +89,75 @@
     padding-bottom: 2em;
   }
 }
+
+/* ============================================================
+   TEXT BLURRING — Training mode
+   ============================================================ */
+
+/* Line-text wrapper inherits colour; transition for reveal animation
+   ::ng-deep required because .line-text is injected via innerHTML */
+:host ::ng-deep .line-text {
+  transition: filter 250ms ease;
+}
+
+/* RX/TX line type markers (classes set on containing element) */
+:host ::ng-deep .blur-rx .rx-line .line-text,
+:host ::ng-deep .blur-tx .tx-line .line-text,
+:host ::ng-deep .blur-both .rx-line .line-text,
+:host ::ng-deep .blur-both .tx-line .line-text {
+  filter: blur(5px);
+}
+
+/* Momentary reveal — overrides blur when held */
+:host ::ng-deep .blur-revealing .rx-line .line-text,
+:host ::ng-deep .blur-revealing .tx-line .line-text {
+  filter: blur(0) !important;
+}
+
+/* Encoder pending chars blur */
+.fs-conversation.blur-tx .fs-encoder-inline,
+.fs-conversation.blur-both .fs-encoder-inline {
+  filter: blur(5px);
+  transition: filter 250ms ease;
+}
+.fs-conversation.blur-revealing .fs-encoder-inline {
+  filter: blur(0) !important;
+}
+
+/* ---- Reveal button (eye icon) ---- */
+.blur-reveal-btn {
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: rgba(60, 60, 80, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 25;
+  padding: 0;
+  min-height: unset;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+  transition: background 0.15s, color 0.15s;
+  touch-action: manipulation;
+  -webkit-user-select: none;
+  user-select: none;
+}
+.blur-reveal-btn:hover {
+  background: rgba(80, 80, 110, 0.85);
+  color: rgba(255, 255, 255, 0.8);
+}
+.blur-reveal-btn:active,
+.blur-reveal-btn.revealing {
+  background: rgba(50, 110, 180, 0.8);
+  color: #fff;
+}
+.blur-reveal-btn svg {
+  display: block;
+  pointer-events: none;
+}

--- a/src/app/components/help/help-ch-config.component.html
+++ b/src/app/components/help/help-ch-config.component.html
@@ -159,8 +159,37 @@
       text, currently-sending character, and background.</li>
 </ul>
 
-<!-- 8.4 Show Prosigns -->
-<h2 id="s8-4">8.4 &nbsp;Show Prosigns</h2>
+<!-- 8.4 Text Blurring -->
+<h2 id="s8-4">8.4 &nbsp;Text Blurring</h2>
+
+<p>
+  Found in <strong>Settings &rarr; Other</strong>. When enabled, decoded and/or
+  encoded text is blurred in both the main screen and fullscreen views,
+  turning Morse Code Studio into a copy-receiving trainer. You hear the
+  morse and write what you think was sent, then reveal the answer to check.
+</p>
+
+<p>
+  The <strong>Applies to</strong> selector controls which text streams are
+  blurred:
+</p>
+<ul>
+  <li><strong>RX Only</strong> &mdash; only received (decoded) text is blurred.</li>
+  <li><strong>TX Only</strong> &mdash; only transmitted (encoded) text is blurred.</li>
+  <li><strong>Both</strong> &mdash; all text is blurred.</li>
+</ul>
+
+<p>
+  To reveal the hidden text, press and hold the <strong>eye button</strong>
+  (<span style="font-size:1.1em">👁️</span>) that appears when
+  blurring is active. The text fades in with a 250&thinsp;ms animation while
+  you hold the button and blurs again when you release it. In the fullscreen
+  conversation views, user-name tags from RTDB relay messages remain visible
+  even when the text is blurred, so you always know who is transmitting.
+</p>
+
+<!-- 8.5 Show Prosigns -->
+<h2 id="s8-5">8.5 &nbsp;Show Prosigns</h2>
 
 <p>
   Found in <strong>Settings &rarr; Other</strong>. When enabled, punctuation
@@ -179,8 +208,8 @@
   regardless of this setting.
 </p>
 
-<!-- 8.5 Prosign Actions -->
-<h2 id="s8-5">8.5 &nbsp;Prosign Actions</h2>
+<!-- 8.6 Prosign Actions -->
+<h2 id="s8-6">8.6 &nbsp;Prosign Actions</h2>
 
 <p>
   Found in <strong>Settings &rarr; Other</strong>. When the master toggle is
@@ -256,8 +285,8 @@
   new lines start without a leading space.
 </p>
 
-<!-- 8.6 Emoji Replacements -->
-<h2 id="s8-6">8.6 &nbsp;Emoji Replacements</h2>
+<!-- 8.7 Emoji Replacements -->
+<h2 id="s8-7">8.7 &nbsp;Emoji Replacements</h2>
 
 <p>
   When enabled, emoji replacements substitute common morse abbreviations,

--- a/src/app/components/help/help-ch-outputs.component.html
+++ b/src/app/components/help/help-ch-outputs.component.html
@@ -265,6 +265,26 @@
   This dual-layer approach (same as MIDI Output &sect;7.5) eliminates
   both hardware cross-talk loops and software routing loops.
 </p>
+<h3>Reconnection</h3>
+<p>
+  Serial Output connections are restored automatically on page load when
+  previously enabled. If a USB adapter is unplugged and replugged, the app
+  detects the new device and attempts to reconnect. When the port reappears
+  at a different index in the browser&rsquo;s port list, the app uses the
+  stored USB Vendor/Product ID to relocate it.
+</p>
+<p>
+  <strong>Browser limitation:</strong> Whether the browser remembers a
+  previously granted port after disconnect depends on the device&rsquo;s
+  USB descriptor. Adapters with a <strong>unique USB serial number</strong>
+  (e.g.&nbsp;genuine FTDI chips) are reliably matched. Some budget chipsets
+  (e.g.&nbsp;CH340 clones without a programmed serial number) may not be
+  recognised by the browser after re-plug, in which case you need to
+  re-grant the port via the <em>+ Add serial port&hellip;</em> dropdown
+  option. This is an inherent Web Serial API / Chromium limitation, not
+  an application issue.
+</p>
+
 <!-- 7.3 WinKeyer -->
 <h2 id="s7-3">7.3 &nbsp;WinKeyer Output (K1EL WinKeyer)</h2>
 
@@ -383,6 +403,23 @@
     audio keying.
   </p>
 </div>
+
+<h3>Reconnection</h3>
+<p>
+  WinKeyer auto-connects on page load when previously enabled, and attempts
+  to reconnect when the USB cable is unplugged and replugged. Retries are
+  sent at increasing intervals (0, 500, 1500, 3000&thinsp;ms) to handle
+  slow USB enumeration. If the port reappears at a different index, the app
+  uses the stored USB Vendor/Product ID to find it.
+</p>
+<p>
+  <strong>Browser limitation:</strong> Whether the browser remembers a
+  previously granted port after disconnect depends on the device&rsquo;s
+  USB descriptor. WKUSB uses an FTDI chip with a unique serial number and
+  is reliably matched in most cases. If the browser does not restore the
+  grant (e.g.&nbsp;after clearing site data), re-grant the port using the
+  <em>+ Add serial port&hellip;</em> dropdown option.
+</p>
 
 <!-- 7.4 MIDI Output -->
 <h2 id="s7-4">7.4 &nbsp;MIDI Output (Key via MIDI)</h2>

--- a/src/app/components/help/help.component.html
+++ b/src/app/components/help/help.component.html
@@ -85,9 +85,10 @@
         <a (click)="scrollTo('s8-1')">8.1 Sound Card Channel Routing</a>
         <a (click)="scrollTo('s8-2')">8.2 Device Profiles</a>
         <a (click)="scrollTo('s8-3')">8.3 Fullscreen Mode</a>
-        <a (click)="scrollTo('s8-4')">8.4 Show Prosigns</a>
-        <a (click)="scrollTo('s8-5')">8.5 Prosign Actions</a>
-        <a (click)="scrollTo('s8-6')">8.6 Emoji Replacements</a>
+        <a (click)="scrollTo('s8-4')">8.4 Text Blurring</a>
+        <a (click)="scrollTo('s8-5')">8.5 Show Prosigns</a>
+        <a (click)="scrollTo('s8-6')">8.6 Prosign Actions</a>
+        <a (click)="scrollTo('s8-7')">8.7 Emoji Replacements</a>
       </div>
 
       <div class="toc-chapter">

--- a/src/app/components/serial-input-edit-modal/serial-input-edit-modal.component.html
+++ b/src/app/components/serial-input-edit-modal/serial-input-edit-modal.component.html
@@ -22,19 +22,16 @@
       <!-- Serial Port selection -->
       <div class="serial-edit-field">
         <label class="serial-edit-label" for="serialEditPort">Serial Port</label>
-        @if (serialInput.ports().length === 0) {
-          <span class="serial-edit-hint">No serial ports available. Connect a USB-serial adapter and re-open this dialog.</span>
-        } @else {
-          <select id="serialEditPort" class="serial-edit-select" [value]="editPortIndex"
-                  (change)="onPortChange($event)">
-            <option [value]="-1">&mdash; Select &mdash;</option>
-            @for (port of serialInput.ports(); track $index) {
-              <option [value]="$index" [selected]="$index === editPortIndex">
-                {{ serialInput.portLabel(port) }}
-              </option>
-            }
-          </select>
-        }
+        <select id="serialEditPort" class="serial-edit-select" [value]="editPortIndex"
+                (change)="onPortChange($event)">
+          <option [value]="-1">&mdash; Select &mdash;</option>
+          @for (port of serialInput.ports(); track $index) {
+            <option [value]="$index" [selected]="$index === editPortIndex">
+              {{ serialInput.portLabel(port) }}
+            </option>
+          }
+          <option value="-2">+ Add serial port&hellip;</option>
+        </select>
       </div>
 
       @if (isSharing) {

--- a/src/app/components/serial-input-edit-modal/serial-input-edit-modal.component.ts
+++ b/src/app/components/serial-input-edit-modal/serial-input-edit-modal.component.ts
@@ -184,7 +184,13 @@ export class SerialInputEditModalComponent implements OnInit, OnDestroy {
 
   /** Handle port selection change */
   onPortChange(event: Event): void {
-    this.editPortIndex = parseInt((event.target as HTMLSelectElement).value, 10);
+    const select = event.target as HTMLSelectElement;
+    if (select.value === '-2') {
+      select.value = String(this.editPortIndex);
+      this.serialInput.requestPort();
+      return;
+    }
+    this.editPortIndex = parseInt(select.value, 10);
     this.refreshSignals();
   }
 

--- a/src/app/components/serial-output-edit-modal/serial-output-edit-modal.component.html
+++ b/src/app/components/serial-output-edit-modal/serial-output-edit-modal.component.html
@@ -22,21 +22,16 @@
       <!-- Serial Port selection -->
       <div class="serial-edit-field">
         <label class="serial-edit-label" for="serialOutEditPort">Serial Port</label>
-        @if (serialOutput.ports().length === 0) {
-          <span class="serial-edit-hint">No serial ports available. Connect a USB-serial adapter and re-open this dialog.</span>
-          <button type="button" class="action-btn" (click)="addPort()" style="margin-top: 0.4rem; align-self: flex-start;">Add Serial Port&hellip;</button>
-        } @else {
-          <select id="serialOutEditPort" class="serial-edit-select" [value]="editPortIndex"
-                  (change)="onPortChange($event)">
-            <option [value]="-1">&mdash; Select &mdash;</option>
-            @for (port of serialOutput.ports(); track $index) {
-              <option [value]="$index" [selected]="$index === editPortIndex">
-                {{ serialOutput.portLabel(port) }}
-              </option>
-            }
-          </select>
-          <button type="button" class="serial-edit-inline-btn" (click)="addPort()">Add Serial Port&hellip;</button>
-        }
+        <select id="serialOutEditPort" class="serial-edit-select" [value]="editPortIndex"
+                (change)="onPortChange($event)">
+          <option [value]="-1">&mdash; Select &mdash;</option>
+          @for (port of serialOutput.ports(); track $index) {
+            <option [value]="$index" [selected]="$index === editPortIndex">
+              {{ serialOutput.portLabel(port) }}
+            </option>
+          }
+          <option value="-2">+ Add serial port&hellip;</option>
+        </select>
       </div>
 
       <!-- Output Pin (DTR / RTS) -->

--- a/src/app/components/serial-output-edit-modal/serial-output-edit-modal.component.ts
+++ b/src/app/components/serial-output-edit-modal/serial-output-edit-modal.component.ts
@@ -85,12 +85,13 @@ export class SerialOutputEditModalComponent implements OnInit {
 
   /** Handle port selection change */
   onPortChange(event: Event): void {
-    this.editPortIndex = parseInt((event.target as HTMLSelectElement).value, 10);
-  }
-
-  /** Prompt user to add a serial port */
-  async addPort(): Promise<void> {
-    await this.serialOutput.requestPort();
+    const select = event.target as HTMLSelectElement;
+    if (select.value === '-2') {
+      select.value = String(this.editPortIndex);
+      this.serialOutput.requestPort();
+      return;
+    }
+    this.editPortIndex = parseInt(select.value, 10);
   }
 
   /** Save the edited mapping after validation */

--- a/src/app/components/settings-modal/settings-other-tab/settings-other-tab.component.html
+++ b/src/app/components/settings-modal/settings-other-tab/settings-other-tab.component.html
@@ -1,7 +1,8 @@
-<!-- Other tab — Sprite Key, Wake Lock, Show Prosigns, Prosign Actions, Emojis -->
+<!-- Other tab — Sprite Key, Wake Lock, Text Blurring, Show Prosigns, Prosign Actions, Emojis -->
 
 <app-sprite-key-card></app-sprite-key-card>
 <app-wake-lock-card></app-wake-lock-card>
+<app-text-blur-card></app-text-blur-card>
 <app-show-prosigns-card></app-show-prosigns-card>
 <app-prosign-actions-card></app-prosign-actions-card>
 <app-emojis-card></app-emojis-card>

--- a/src/app/components/settings-modal/settings-other-tab/settings-other-tab.component.ts
+++ b/src/app/components/settings-modal/settings-other-tab/settings-other-tab.component.ts
@@ -5,6 +5,7 @@
 import { Component } from '@angular/core';
 import { SpriteKeyCardComponent } from './sprite-key-card/sprite-key-card.component';
 import { WakeLockCardComponent } from './wake-lock-card/wake-lock-card.component';
+import { TextBlurCardComponent } from './text-blur-card/text-blur-card.component';
 import { ShowProsignsCardComponent } from './show-prosigns-card/show-prosigns-card.component';
 import { ProsignActionsCardComponent } from './prosign-actions-card/prosign-actions-card.component';
 import { EmojisCardComponent } from './emojis-card/emojis-card.component';
@@ -12,7 +13,7 @@ import { EmojisCardComponent } from './emojis-card/emojis-card.component';
 /**
  * Settings — Other tab.
  *
- * Thin shell that renders the five miscellaneous settings cards as
+ * Thin shell that renders the six miscellaneous settings cards as
  * independent child components. Each card encapsulates its own
  * expand/collapse state, service injections, and event handlers.
  */
@@ -22,6 +23,7 @@ import { EmojisCardComponent } from './emojis-card/emojis-card.component';
   imports: [
     SpriteKeyCardComponent,
     WakeLockCardComponent,
+    TextBlurCardComponent,
     ShowProsignsCardComponent,
     ProsignActionsCardComponent,
     EmojisCardComponent,

--- a/src/app/components/settings-modal/settings-other-tab/text-blur-card/text-blur-card.component.html
+++ b/src/app/components/settings-modal/settings-other-tab/text-blur-card/text-blur-card.component.html
@@ -1,0 +1,33 @@
+<!-- Text Blurring -->
+<div class="settings-card" [class.disabled-card]="!settings.settings().textBlurEnabled">
+  <div class="settings-card-header" (click)="expanded = !expanded">
+    <div class="settings-card-title">
+      <span class="settings-card-chevron">{{ expanded ? '&#9660;' : '&#9654;' }}</span>
+      <span class="settings-card-name">Text Blurring</span>
+    </div>
+    <label class="toggle-switch" (click)="$event.stopPropagation()">
+      <input type="checkbox" [checked]="settings.settings().textBlurEnabled"
+             (change)="onEnabledChange($event)">
+      <span class="toggle-slider"></span>
+    </label>
+  </div>
+  @if (expanded) {
+    <div class="settings-card-body">
+      <div class="cw-hint">
+        Blurs decoded text so you can practice reading Morse by ear
+        without accidentally seeing the answer. A momentary reveal
+        button appears in the text area — press and hold to peek at
+        the blurred text.
+      </div>
+      <label>
+        Applies to:
+        <select [value]="settings.settings().textBlurAppliesTo"
+                (change)="onAppliesToChange($event)">
+          <option value="rx">RX Only</option>
+          <option value="tx">TX Only</option>
+          <option value="both">Both RX and TX</option>
+        </select>
+      </label>
+    </div>
+  }
+</div>

--- a/src/app/components/settings-modal/settings-other-tab/text-blur-card/text-blur-card.component.ts
+++ b/src/app/components/settings-modal/settings-other-tab/text-blur-card/text-blur-card.component.ts
@@ -1,0 +1,41 @@
+/**
+ * Morse Code Studio
+ */
+
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { SettingsService } from '../../../../services/settings.service';
+
+/**
+ * Settings card — Text Blurring.
+ *
+ * Blurs decoded text in both main screen and fullscreen views for
+ * training purposes. Users can choose to blur RX only, TX only, or
+ * both directions. A momentary reveal button in the text areas lets
+ * users peek at the blurred text by pressing and holding.
+ */
+@Component({
+  selector: 'app-text-blur-card',
+  standalone: true,
+  imports: [FormsModule],
+  templateUrl: './text-blur-card.component.html',
+  styles: [':host { display: contents; }'],
+})
+export class TextBlurCardComponent {
+  /** Whether this card's body is expanded */
+  expanded = false;
+
+  constructor(public settings: SettingsService) {}
+
+  /** Handle text blur toggle change */
+  onEnabledChange(event: Event): void {
+    const checked = (event.target as HTMLInputElement).checked;
+    this.settings.update({ textBlurEnabled: checked });
+  }
+
+  /** Handle applies-to selection change */
+  onAppliesToChange(event: Event): void {
+    const value = (event.target as HTMLSelectElement).value as 'rx' | 'tx' | 'both';
+    this.settings.update({ textBlurAppliesTo: value });
+  }
+}

--- a/src/app/components/settings-modal/settings-outputs-tab/winkeyer-card/winkeyer-card.component.html
+++ b/src/app/components/settings-modal/settings-outputs-tab/winkeyer-card/winkeyer-card.component.html
@@ -1,6 +1,6 @@
 <!-- WinKeyer Output -->
 <div class="settings-card" [class.disabled-card]="!settings.settings().winkeyerEnabled">
-  <div class="settings-card-header" (click)="expanded = !expanded">
+  <div class="settings-card-header" (click)="toggleExpand()">
     <div class="settings-card-title">
       <span class="settings-card-chevron">{{ expanded ? '&#9660;' : '&#9654;' }}</span>
       <span class="settings-card-name">WinKeyer Output</span>
@@ -44,35 +44,18 @@
           Chrome or Edge on a desktop operating system (Windows, macOS, Linux, or ChromeOS).
         </div>
       }
-      <div class="serial-port-row">
-        <button (click)="winkeyerOutput.requestPort()" class="test-btn">
-          Add Serial Port&hellip;
-        </button>
-        <button (click)="winkeyerOutput.refreshPorts()" class="test-btn">
-          Refresh
-        </button>
-      </div>
-
-      @if (winkeyerOutput.ports().length === 0) {
-        <div class="cw-hint">
-          No serial ports available. Click "Add Serial Port&hellip;" to grant access to the WinKeyer's COM port.
-          Requires a Chromium-based browser (Chrome, Edge) with Web Serial API support.
-        </div>
-      }
-
-      @if (winkeyerOutput.ports().length > 0) {
-        <label>WinKeyer Port:
-          <select [value]="settings.settings().winkeyerPortIndex"
-                  (change)="onWinkeyerPortChange($event)">
-            <option [value]="-1">&mdash; Select &mdash;</option>
-            @for (port of winkeyerOutput.ports(); track $index) {
-              <option [value]="$index" [selected]="$index === settings.settings().winkeyerPortIndex">
-                {{ winkeyerOutput.portLabel(port) }}
-              </option>
-            }
-          </select>
-        </label>
-      }
+      <label>WinKeyer Port:
+        <select [value]="settings.settings().winkeyerPortIndex"
+                (change)="onWinkeyerPortChange($event)">
+          <option [value]="-1">&mdash; Select &mdash;</option>
+          @for (port of winkeyerOutput.ports(); track $index) {
+            <option [value]="$index" [selected]="$index === settings.settings().winkeyerPortIndex">
+              {{ winkeyerOutput.portLabel(port) }}
+            </option>
+          }
+          <option value="-2">+ Add serial port&hellip;</option>
+        </select>
+      </label>
 
       <label>WPM Speed:
         <input type="number" min="5" max="99" [value]="settings.settings().winkeyerWpm"

--- a/src/app/components/settings-modal/settings-outputs-tab/winkeyer-card/winkeyer-card.component.ts
+++ b/src/app/components/settings-modal/settings-outputs-tab/winkeyer-card/winkeyer-card.component.ts
@@ -36,6 +36,34 @@ export class WinkeyerCardComponent {
     public winkeyerOutput: WinkeyerOutputService,
   ) {}
 
+  /** Toggle card expansion; refresh port list when opening */
+  toggleExpand(): void {
+    this.expanded = !this.expanded;
+    if (this.expanded) {
+      this.winkeyerOutput.refreshPorts();
+    }
+  }
+
+  /**
+   * Handle WinKeyer port selection.
+   * The special value "-2" triggers the browser's port-request dialog.
+   */
+  async onWinkeyerPortChange(event: Event): Promise<void> {
+    const select = event.target as HTMLSelectElement;
+    const raw = select.value;
+    if (raw === '-2') {
+      select.value = String(this.settings.settings().winkeyerPortIndex);
+      await this.winkeyerOutput.requestPort();
+      return;
+    }
+    const idx = parseInt(raw, 10);
+    this.settings.update({ winkeyerPortIndex: idx });
+    await this.winkeyerOutput.close();
+    if (idx >= 0) {
+      await this.winkeyerOutput.open(idx);
+    }
+  }
+
   /** Handle a string or numeric setting change */
   onSettingChange(key: keyof AppSettings, event: Event): void {
     const el = event.target as HTMLInputElement;
@@ -44,16 +72,6 @@ export class WinkeyerCardComponent {
       value = parseFloat(el.value);
     }
     this.settings.update({ [key]: value } as Partial<AppSettings>);
-  }
-
-  /** Handle WinKeyer port selection — closes current and opens selected */
-  async onWinkeyerPortChange(event: Event): Promise<void> {
-    const idx = parseInt((event.target as HTMLSelectElement).value, 10);
-    this.settings.update({ winkeyerPortIndex: idx });
-    await this.winkeyerOutput.close();
-    if (idx >= 0) {
-      await this.winkeyerOutput.open(idx);
-    }
   }
 
   /** Handle WinKeyer enabled toggle — opens/closes the WinKeyer connection */

--- a/src/app/services/serial-key-output.service.ts
+++ b/src/app/services/serial-key-output.service.ts
@@ -91,6 +91,9 @@ export class SerialKeyOutputService {
   /** Whether the initial auto-connect has been attempted (one-shot guard) */
   private autoConnectAttempted = false;
 
+  /** VID/PID of ports that were previously connected, keyed by port index */
+  private portVidPids = new Map<number, { vid: number; pid: number }>();
+
   constructor(
     private settings: SettingsService,
     private zone: NgZone,
@@ -380,6 +383,13 @@ export class SerialKeyOutputService {
       const map = new Map(this.openPorts());
       map.set(portIndex, { port, disconnectHandler });
       this.openPorts.set(map);
+
+      // Remember VID/PID for reconnection matching
+      const info = port.getInfo();
+      if (info.usbVendorId !== undefined) {
+        this.portVidPids.set(portIndex, { vid: info.usbVendorId, pid: info.usbProductId ?? 0 });
+      }
+
       this.lastError.set(null);
     } catch (e: any) {
       if (e.message?.includes('already open')) {
@@ -396,6 +406,13 @@ export class SerialKeyOutputService {
         const map = new Map(this.openPorts());
         map.set(portIndex, { port, disconnectHandler });
         this.openPorts.set(map);
+
+        // Remember VID/PID for reconnection matching
+        const info = port.getInfo();
+        if (info.usbVendorId !== undefined) {
+          this.portVidPids.set(portIndex, { vid: info.usbVendorId, pid: info.usbProductId ?? 0 });
+        }
+
         this.lastError.set(null);
         return;
       }
@@ -497,6 +514,7 @@ export class SerialKeyOutputService {
   /**
    * Handle a serial device being physically connected.
    * Attempt to re-open any configured ports that are not yet connected.
+   * Falls back to VID/PID matching if stored port indices are stale.
    */
   private handleSerialConnect(): void {
     if (!this.settings.settings().serialEnabled) return;
@@ -505,6 +523,7 @@ export class SerialKeyOutputService {
     setTimeout(async () => {
       try {
         await this.refreshPorts();
+        this.remapStalePortIndices();
         await this.connectAllEnabled();
       } finally {
         this.reconnecting = false;
@@ -515,6 +534,7 @@ export class SerialKeyOutputService {
   /**
    * Auto-connect to the configured ports on startup.
    * Retries with increasing delays to handle late USB enumeration.
+   * Falls back to VID/PID matching if stored port indices are stale.
    */
   private async autoConnectAll(portIndices: number[]): Promise<void> {
     if (this.reconnecting) return;
@@ -523,15 +543,53 @@ export class SerialKeyOutputService {
       for (const delay of [0, 500, 1500, 3000]) {
         if (delay > 0) await new Promise(r => setTimeout(r, delay));
         await this.refreshPorts();
-        for (const idx of portIndices) {
+        this.remapStalePortIndices();
+        // Re-read indices after potential remap
+        const s = this.settings.settings();
+        const currentIndices = new Set(
+          s.serialOutputMappings.filter(m => m.enabled && m.portIndex >= 0).map(m => m.portIndex)
+        );
+        for (const idx of currentIndices) {
           if (!this.openPorts().has(idx) && idx < this.ports().length) {
             await this.open(idx);
           }
         }
-        if (portIndices.every(idx => this.openPorts().has(idx))) return;
+        if ([...currentIndices].every(idx => this.openPorts().has(idx))) return;
       }
     } finally {
       this.reconnecting = false;
+    }
+  }
+
+  /**
+   * Remap stale port indices in serialOutputMappings.
+   * If a mapping references a port index that is out of range but we
+   * have a stored VID/PID for it, scan current ports for a match
+   * and update the mapping to the new index.
+   */
+  private remapStalePortIndices(): void {
+    const ports = this.ports();
+    const s = this.settings.settings();
+    let updated = false;
+    const updatedMappings = s.serialOutputMappings.map(m => {
+      if (m.portIndex < 0 || m.portIndex < ports.length) return m;
+      // Port index is out of range — try VID/PID match
+      const vidPid = this.portVidPids.get(m.portIndex);
+      if (!vidPid) return m;
+      for (let i = 0; i < ports.length; i++) {
+        const info = ports[i].getInfo();
+        if (info.usbVendorId === vidPid.vid &&
+            (info.usbProductId ?? 0) === vidPid.pid) {
+          updated = true;
+          this.portVidPids.delete(m.portIndex);
+          this.portVidPids.set(i, vidPid);
+          return { ...m, portIndex: i };
+        }
+      }
+      return m;
+    });
+    if (updated) {
+      this.settings.update({ serialOutputMappings: updatedMappings });
     }
   }
 }

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -376,6 +376,12 @@ export interface AppSettings {
   /** Animate the sprite when serial straight key is pressed */
   spriteAnimateSerial: boolean;
 
+  // --- Text Blurring ---
+  /** Blur decoded text for training purposes */
+  textBlurEnabled: boolean;
+  /** Which text directions to blur: rx, tx, or both */
+  textBlurAppliesTo: 'rx' | 'tx' | 'both';
+
   // --- Screen Wake Lock ---
   /** Keep the screen active to prevent idle sleep (mobile devices) */
   wakeLockEnabled: boolean;
@@ -653,6 +659,9 @@ const DEFAULT_SETTINGS: AppSettings = {
   spriteAnimateMidi: false,
   spriteAnimateMic: false,
   spriteAnimateSerial: false,
+
+  textBlurEnabled: false,
+  textBlurAppliesTo: 'rx',
 
   wakeLockEnabled: false,
 

--- a/src/app/services/winkeyer-output.service.ts
+++ b/src/app/services/winkeyer-output.service.ts
@@ -2,7 +2,7 @@
  * Morse Code Studio
  */
 
-import { Injectable, NgZone, signal } from '@angular/core';
+import { Injectable, NgZone, effect, signal } from '@angular/core';
 import { SettingsService } from './settings.service';
 import { PROSIGN_TO_PUNCTUATION } from '../morse-table';
 
@@ -95,6 +95,9 @@ export class WinkeyerOutputService {
   /** Background reader loop abort flag */
   private readLoopRunning = false;
 
+  /** VID/PID of the last successfully connected port, for reconnect matching */
+  private lastConnectedVidPid: { vid: number; pid: number } | null = null;
+
   /** Bound handler for navigator.serial connect events */
   private readonly onSerialConnect = () => this.handleSerialConnect();
 
@@ -103,6 +106,9 @@ export class WinkeyerOutputService {
 
   /** Whether auto-reconnect is in progress */
   private reconnecting = false;
+
+  /** Whether the initial auto-connect has been attempted (one-shot guard) */
+  private autoConnectAttempted = false;
 
   /** Latest status byte from WinKeyer */
   readonly status = signal(0);
@@ -119,6 +125,18 @@ export class WinkeyerOutputService {
     if ('serial' in navigator) {
       navigator.serial.addEventListener('connect', this.onSerialConnect);
     }
+
+    // Auto-open on page load if previously enabled.
+    // Chrome remembers granted ports via getPorts(), so no user gesture
+    // is needed. The one-shot guard prevents this from interfering
+    // with explicit connect/disconnect actions from the settings card.
+    effect(() => {
+      const s = this.settings.settings();
+      if (!this.autoConnectAttempted && s.winkeyerEnabled && s.winkeyerPortIndex >= 0) {
+        this.autoConnectAttempted = true;
+        queueMicrotask(() => this.autoConnectWithRetries());
+      }
+    });
   }
 
   // ---- Port Management ----
@@ -203,19 +221,22 @@ export class WinkeyerOutputService {
 
       // Listen for physical disconnection of this port
       this.portDisconnectHandler = () => {
-        this.zone.run(() => {
+        this.zone.run(async () => {
           this.readLoopRunning = false;
           try { this.reader?.cancel(); } catch { /* ignore */ }
           try { this.reader?.releaseLock(); } catch { /* ignore */ }
           this.reader = null;
           try { this.writer?.releaseLock(); } catch { /* ignore */ }
           this.writer = null;
+          const disconnectedPort = this.activePort;
           this.activePort = null;
           this.connected.set(false);
           this.firmwareVersion.set(0);
           this.status.set(0);
           this.busy.set(false);
           this.portDisconnectHandler = null;
+          // Try to close the port (may fail if already gone)
+          try { await disconnectedPort?.close(); } catch { /* ignore */ }
           this.refreshPorts();
         });
       };
@@ -242,6 +263,12 @@ export class WinkeyerOutputService {
       // Set speed from settings
       const wpm = this.settings.settings().winkeyerWpm;
       await this.writeBytes([WK_SET_SPEED, Math.max(5, Math.min(99, wpm))]);
+
+      // Remember the port's USB identity for reconnection matching
+      const info = port.getInfo();
+      if (info.usbVendorId !== undefined) {
+        this.lastConnectedVidPid = { vid: info.usbVendorId, pid: info.usbProductId ?? 0 };
+      }
 
       this.connected.set(true);
       this.lastError.set(null);
@@ -487,25 +514,66 @@ export class WinkeyerOutputService {
 
   /**
    * Handle a serial device being physically connected.
-   * If the service is enabled and currently disconnected, attempt to
-   * re-open the configured port after a short settling delay.
+   * If the service is enabled, attempt to close any stale connection
+   * and re-open the configured port with retries.
    */
   private handleSerialConnect(): void {
     if (!this.settings.settings().winkeyerEnabled) return;
-    if (this.connected()) return;
+    if (this.reconnecting) return;
+    // Close any stale connection first (handles race where disconnect
+    // event hasn't fired yet when the new connect event arrives)
+    if (this.connected()) {
+      this.close().then(() => this.autoConnectWithRetries());
+    } else {
+      this.autoConnectWithRetries();
+    }
+  }
+
+  /**
+   * Find a port by VID/PID match, returning its index or -1.
+   * Used as fallback when the stored port index is out of range
+   * (e.g. device reappeared at a different position after re-plug).
+   */
+  private findPortByVidPid(): number {
+    if (!this.lastConnectedVidPid) return -1;
+    const ports = this.ports();
+    for (let i = 0; i < ports.length; i++) {
+      const info = ports[i].getInfo();
+      if (info.usbVendorId === this.lastConnectedVidPid.vid &&
+          (info.usbProductId ?? 0) === this.lastConnectedVidPid.pid) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Auto-connect to the configured port with retries.
+   * Retries with increasing delays to handle late USB enumeration.
+   * Falls back to VID/PID matching if the stored index is stale.
+   */
+  private async autoConnectWithRetries(): Promise<void> {
     if (this.reconnecting) return;
     this.reconnecting = true;
-    // Allow the port to settle before attempting to open
-    setTimeout(async () => {
-      try {
+    try {
+      for (const delay of [0, 500, 1500, 3000]) {
+        if (delay > 0) await this.sleep(delay);
         await this.refreshPorts();
-        const idx = this.settings.settings().winkeyerPortIndex;
+        let idx = this.settings.settings().winkeyerPortIndex;
+        if (idx < 0 || idx >= this.ports().length) {
+          // Stored index is stale — try VID/PID match
+          idx = this.findPortByVidPid();
+          if (idx >= 0) {
+            this.settings.update({ winkeyerPortIndex: idx });
+          }
+        }
         if (idx >= 0 && idx < this.ports().length && !this.connected()) {
           await this.open(idx);
         }
-      } finally {
-        this.reconnecting = false;
+        if (this.connected()) return;
       }
-    }, 1000);
+    } finally {
+      this.reconnecting = false;
+    }
   }
 }

--- a/src/app/version.ts
+++ b/src/app/version.ts
@@ -1,2 +1,2 @@
 /** Single source of truth for the application version displayed in the UI. */
-export const APP_VERSION = '1.4.0';
+export const APP_VERSION = '1.5.0';


### PR DESCRIPTION
## Description

- **Text Blurring (Training Mode)** — New setting under Settings → Other that
  blurs decoded text so you can practice reading Morse by ear without
  accidentally seeing the answer. Configurable to blur RX only, TX only, or
  both directions. A floating eye button in the text area acts as a momentary
  reveal switch — press and hold to unblur with a 250 ms animated transition.
  Works in both the main screen parchment view and fullscreen decoder/encoder
  views. Name tags remain visible; only the text content is blurred. Text
  colour is preserved through the blur effect.
- **Inline Port Granting** — All serial port dropdowns (WinKeyer, Serial Input
  edit modal, Serial Output edit modal) now include a `+ Add serial port…`
  option directly in the select box. Selecting it opens the browser's port
  permission dialog without needing to navigate to a different service's
  settings first.

## Related Issue

Closes #6

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] My code follows the existing code style of the project
- [X] The app builds without errors (`ng build`)
- [X] I have tested my changes in Chrome or Edge
- [X] I have added/updated documentation as needed
