### PR TITLE
allow midi and serial relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-03-15
+
+### Added
+
+- **Per-Mapping Input Relay** — MIDI and Serial output mappings now have a
+  "Relay from…" multi-select in their edit modal, letting you choose exactly
+  which input mappings are forwarded through each output. Only input mappings
+  whose source matches the output's forward direction (RX/TX) are shown,
+  giving fine-grained control to prevent feedback loops while still allowing
+  deliberate relay between separate hardware paths.
+- **RTDB Input Relay** — New "Allow input relay" checkbox on the RTDB Output
+  card. When enabled, characters received from the RTDB channel are relayed
+  back out (useful for multi-site bridging). Automatically disabled when the
+  RTDB input and output share the same channel and secret to prevent echo.
+- **Suppress Other Inputs** — New per-mapping checkbox (MIDI Output, Serial
+  Output, and RTDB Output) that appears when relay sources are selected.
+  When enabled, the output only forwards signals from the explicitly chosen
+  relay sources — all other input paths are suppressed.
+
+### Fixed
+
+- **MIDI/Serial Feedback Loop Prevention** — The three anti-echo layers
+  (input-service muting, decoder output gating, and forwarding-effect
+  filtering) now operate per-mapping instead of globally. This fixes feedback
+  loops that occurred when relay was enabled globally but multiple mappings
+  shared the same physical bus.
+- **Relay Index Cleanup** — Deleting a MIDI or Serial input mapping now
+  correctly removes and re-indexes relay references in the corresponding
+  output mappings, preventing stale or shifted indices.
+- **Loop Detection False Positives on Relay** — Characters from
+  relay-allowed input paths (MIDI or Serial inputs configured in an output
+  mapping's "Relay from…" list) are now excluded from the loop-detection
+  input buffer, preventing false-positive loop suppression when the
+  repeated sequence is intentional relay traffic.
+
+### Changed
+
+- **Mapping Conflict Detection Downgraded to Warning** — MIDI Output and
+  Serial Output edit modals no longer block saving when two mappings share
+  the same note/device/channel (MIDI) or port/pin (Serial). The check is now
+  a non-blocking yellow warning, since overlapping mappings are valid when
+  they fire under different conditions (e.g. different forward directions or
+  relay sources with "Suppress other inputs" enabled).
+
 ## [1.6.0] - 2026-03-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "morse-code-studio",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "morse-code-studio",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "CC0-1.0",
       "dependencies": {
         "@angular/animations": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morse-code-studio",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A browser-based Morse code encoder, decoder and keyer built with Angular and the Web Audio API",
   "author": "5B4AON — Mike",
   "repository": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -182,8 +182,32 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
           const displayName = this.getDisplayName(entry.type, entry.name);
           this.displayBuffers.pushDecoded(entry.type, entry.char, displayName, entry.color);
 
-          // Record input for loop detection (non-RTDB chars are from local inputs)
-          if (!entry.fromRtdb) {
+          // Compute whether this entry is from a relay-allowed input path.
+          // Used both for loop detection exclusion and for output forwarding.
+          const s = this.settings.settings();
+          let isRelayEntry = false;
+          let midiRelayIndex: number | undefined;
+          if (entry.fromMidi && entry.inputPath) {
+            const m = entry.inputPath.match(/^midi(?:StraightKey|Paddle):(\d+)/);
+            if (m) {
+              midiRelayIndex = parseInt(m[1], 10);
+              isRelayEntry = s.midiOutputMappings.some(
+                om => om.enabled && om.relayInputIndices.includes(midiRelayIndex!),
+              );
+            }
+          } else if (entry.fromSerial && entry.inputPath) {
+            const m = entry.inputPath.match(/^serial(?:StraightKey|Paddle):(\d+)/);
+            if (m) {
+              const serialRelayIndex = parseInt(m[1], 10);
+              isRelayEntry = s.serialOutputMappings.some(
+                om => om.enabled && om.relayInputIndices.includes(serialRelayIndex),
+              );
+            }
+          }
+
+          // Record input for loop detection (skip RTDB chars and relay-allowed
+          // entries — relay traffic is intentional, not a hardware loop)
+          if (!entry.fromRtdb && !isRelayEntry) {
             this.loopDetection.recordInput(entry.char);
           }
 
@@ -199,22 +223,50 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
           this.winkeyerOutput.forwardDecodedChar(entry.char, entry.type);
 
           // Forward to MIDI output — skip chars that originated from MIDI input
-          // or serial input (prevents echo loops). Local keyer pipelines
-          // (keyboard, mouse, touch) already fire straight-key notes in
-          // real-time via keyDown/keyUp, so pass paddleOnly=true for those
-          // to avoid double-firing straight-key mappings while still
-          // driving paddle-mode mappings through the character path.
-          if (!entry.fromMidi && !entry.fromSerial) {
-            const isLocalKeyer = entry.inputPath &&
-              (entry.inputPath === 'keyboardStraightKey' || entry.inputPath.startsWith('keyboardPaddle') ||
-               entry.inputPath === 'mouseStraightKey' || entry.inputPath === 'mousePaddle' ||
-               entry.inputPath === 'touchStraightKey' || entry.inputPath === 'touchPaddle');
-            this.midiOutput.forwardDecodedChar(entry.char, entry.type, entry.wpm, !!isLocalKeyer);
+          // or serial input (prevents echo loops), unless the specific input
+          // mapping is configured as a relay source in at least one output
+          // mapping's relayInputIndices.
+          // Local keyer pipelines (keyboard, mouse, touch) already fire
+          // straight-key notes in real-time via keyDown/keyUp, so pass
+          // paddleOnly=true for those (and for MIDI relay entries whose
+          // straight-key notes are already fired via the decoder) to avoid
+          // double-firing straight-key mappings while still driving
+          // paddle-mode mappings through the character path.
+          {
+            const midiAllowed = !entry.fromMidi || isRelayEntry;
+            const serialAllowed = !entry.fromSerial;
+            if (midiAllowed && serialAllowed) {
+              const isLocalKeyer = entry.inputPath &&
+                (entry.inputPath === 'keyboardStraightKey' || entry.inputPath.startsWith('keyboardPaddle') ||
+                 entry.inputPath === 'mouseStraightKey' || entry.inputPath === 'mousePaddle' ||
+                 entry.inputPath === 'touchStraightKey' || entry.inputPath === 'touchPaddle');
+              // MIDI relay entries already have real-time keyDown/keyUp for straight-key notes
+              const paddleOnly = !!isLocalKeyer || !!entry.fromMidi;
+              this.midiOutput.forwardDecodedChar(entry.char, entry.type, entry.wpm, paddleOnly, isRelayEntry);
+            }
           }
 
-          // Forward to RTDB output only for non-RTDB chars (prevent echo)
-          if (!entry.fromRtdb) {
-            this.rtdbService.forwardDecodedChar(entry.char, entry.type, entry.wpm, entry.name, entry.color);
+          // Forward to RTDB output only for non-RTDB chars (prevent echo),
+          // unless the user has enabled relay AND input/output use different
+          // channel+secret combinations.
+          // When rtdbRelaySuppressOtherInputs is on, only RTDB relay chars
+          // are forwarded — all other input sources are suppressed.
+          {
+            const inCh = s.rtdbInputChannelName.trim();
+            const inSec = s.rtdbInputChannelSecret.trim();
+            const outCh = s.rtdbOutputChannelName.trim();
+            const outSec = s.rtdbOutputChannelSecret.trim();
+            const sameChannel = !!(inCh && outCh && inCh === outCh && inSec === outSec);
+            const rtdbRelayAllowed = s.rtdbAllowInputRelay && !sameChannel;
+            const rtdbSuppressOther = s.rtdbRelaySuppressOtherInputs && rtdbRelayAllowed;
+            if (rtdbSuppressOther) {
+              // Only forward chars that come from RTDB relay
+              if (entry.fromRtdb) {
+                this.rtdbService.forwardDecodedChar(entry.char, entry.type, entry.wpm, entry.name, entry.color, true);
+              }
+            } else if (!entry.fromRtdb || rtdbRelayAllowed) {
+              this.rtdbService.forwardDecodedChar(entry.char, entry.type, entry.wpm, entry.name, entry.color, !!entry.fromRtdb);
+            }
           }
         }
       }

--- a/src/app/components/help/help-ch-firebase.component.html
+++ b/src/app/components/help/help-ch-firebase.component.html
@@ -125,9 +125,13 @@
   vibration outputs are set to "Both", so you will hear the incoming morse
   and feel a haptic pulse. If you also set the optocoupler, serial port or
   WinKeyer output to "RX" or "Both", the received characters will key those
-  outputs as well — useful for relaying an RTDB-received signal to a
-  transmitter. Characters received from RTDB are <em>never</em> echoed back
-  to the RTDB output, preventing network loops.
+  outputs as well &mdash; useful for relaying an RTDB-received signal to a
+  transmitter. By default, characters received from RTDB are
+  <em>not</em> echoed back to the RTDB output. To enable RTDB-to-RTDB
+  relay (e.g. for multi-site bridging), check <strong>Allow input
+  relay</strong> on the RTDB Output card. This checkbox is automatically
+  disabled when the RTDB input and output share the same channel and
+  secret, preventing network loops.
 </p>
 
 <!-- 10.4 Output (Transmit) -->
@@ -190,6 +194,21 @@
         <li><strong>Both</strong> — all decoded characters</li>
       </ul>
     </td>
+  </tr>
+  <tr>
+    <td><strong>Allow input relay</strong></td>
+    <td>When checked, characters received from the RTDB input channel
+        are relayed back to the RTDB output &mdash; useful for multi-site
+        bridging. Automatically disabled (greyed out) when the input
+        and output share the same channel and secret, to prevent
+        network loops.</td>
+  </tr>
+  <tr>
+    <td><strong>Suppress other inputs</strong></td>
+    <td>Appears when &ldquo;Allow input relay&rdquo; is enabled. When
+        checked, only characters received from the RTDB input channel
+        are forwarded to RTDB output; all other local input paths
+        (keyer, encoder, audio decoder, etc.) are suppressed.</td>
   </tr>
 </table>
 <p>

--- a/src/app/components/help/help-ch-inputs.component.html
+++ b/src/app/components/help/help-ch-inputs.component.html
@@ -253,6 +253,13 @@
     bus or source routing (RX/TX). The same pattern applies to Serial
     Input (&sect;6.3).
   </p>
+  <p>
+    When input and output use <em>separate</em> hardware, you can
+    selectively bypass these protections per output mapping using the
+    <strong>Relay from&hellip;</strong> setting in the output mapping&rsquo;s
+    edit modal (&sect;7.4 for MIDI, &sect;7.2 for Serial). This allows
+    deliberate relay without opening the door to accidental loops.
+  </p>
 </div>
 
 <div class="example-box">
@@ -534,6 +541,13 @@
     with Serial Output and MIDI Output &mdash; even when using the same
     adapter and the same source routing (RX/TX). The same pattern applies
     to MIDI Input (&sect;6.2).
+  </p>
+  <p>
+    When input and output use <em>separate</em> adapters, you can
+    selectively bypass these protections per output mapping using the
+    <strong>Relay from&hellip;</strong> setting in the output mapping&rsquo;s
+    edit modal (&sect;7.2 for Serial, &sect;7.4 for MIDI). This allows
+    deliberate relay without opening the door to accidental loops.
   </p>
 </div>
 

--- a/src/app/components/help/help-ch-outputs.component.html
+++ b/src/app/components/help/help-ch-outputs.component.html
@@ -173,6 +173,19 @@
       When checked, the polarity is reversed (idle = HIGH, keyed = LOW).</li>
   <li><strong>Forward</strong> &mdash; Which signal sources drive this
       mapping: TX only, RX only, or Both.</li>
+  <li><strong>Relay from Serial Input</strong> &mdash; Multi-select list of
+      Serial Input mappings whose forward direction matches this output
+      mapping&rsquo;s forward direction. Selected inputs are allowed to
+      relay through this output, bypassing the normal echo-prevention
+      layers. Use this when input and output are on <em>separate</em>
+      adapters and you want decoded serial input characters to be
+      re-keyed on serial output. Only compatible input mappings (matching
+      RX/TX/Both) are shown.</li>
+  <li><strong>Suppress other inputs</strong> &mdash; Appears when at least
+      one relay source is selected. When checked, this output mapping
+      <em>only</em> forwards signals from the selected relay sources;
+      all other input paths (keyer, encoder, audio decoder, etc.) are
+      suppressed for this mapping.</li>
   <li><strong>Test Output</strong> &mdash; Keys the output for 1 second to verify
       wiring. Available when the mapping&rsquo;s port is connected.</li>
 </ul>
@@ -264,6 +277,17 @@
 <p>
   This dual-layer approach (same as MIDI Output &sect;7.5) eliminates
   both hardware cross-talk loops and software routing loops.
+</p>
+<h4>Per-mapping relay override</h4>
+<p>
+  When input and output use <em>separate</em> adapters with no shared bus,
+  you can selectively bypass the echo prevention for specific input
+  mappings using the <strong>Relay from Serial Input</strong> multi-select
+  in the output mapping&rsquo;s edit modal. Only the selected input
+  mappings are allowed to activate that output; all other inputs remain
+  blocked by the normal echo-prevention layers. This per-mapping
+  granularity prevents accidental loops while allowing deliberate relay
+  between physically separate hardware paths.
 </p>
 <h3>Reconnection</h3>
 <p>
@@ -571,6 +595,19 @@
       WPM speed. By default MIDI output uses that remote speed so the
       playback matches the sender&rsquo;s timing. Enable this option to
       ignore the remote WPM and use your local Encoder WPM instead.</li>
+  <li><strong>Relay from MIDI Input</strong> &mdash; Multi-select list of
+      MIDI Input mappings whose forward direction matches this output
+      mapping&rsquo;s forward direction. Selected inputs are allowed to
+      relay through this output, bypassing the normal echo-prevention
+      layers. Use this when input and output are on <em>separate</em>
+      hardware paths and you want decoded MIDI input characters to be
+      replayed on MIDI output. Only compatible input mappings (matching
+      RX/TX/Both) are shown.</li>
+  <li><strong>Suppress other inputs</strong> &mdash; Appears when at least
+      one relay source is selected. When checked, this output mapping
+      <em>only</em> forwards signals from the selected relay sources;
+      all other input paths (keyer, encoder, audio decoder, etc.) are
+      suppressed for this mapping.</li>
   <li><strong>Test</strong> &mdash; Sends a 1-second note-on/off on
       the mapping&rsquo;s note to verify the connection.</li>
 </ul>
@@ -615,6 +652,17 @@
   path to MIDI output. This dual-layer design (same as Serial Output
   &sect;7.2) eliminates both hardware bus echoes and software routing
   loops.
+</p>
+<h4>Per-mapping relay override</h4>
+<p>
+  When input and output use <em>separate</em> MIDI devices with no shared
+  bus, you can selectively bypass the echo prevention for specific input
+  mappings using the <strong>Relay from MIDI Input</strong> multi-select
+  in the output mapping&rsquo;s edit modal. Only the selected input
+  mappings are allowed to activate that output; all other inputs remain
+  blocked by the normal echo-prevention layers. This per-mapping
+  granularity prevents accidental loops while allowing deliberate relay
+  between physically separate hardware.
 </p>
 
 <div class="example-box">
@@ -756,6 +804,18 @@
   appears at the top of the page with a brief explanation. You can dismiss
   the banner manually by clicking the &times; button, which also clears
   the suppression immediately.
+</p>
+
+<h3>Relay Exclusion</h3>
+<p>
+  Characters arriving from a <strong>relay-allowed</strong> input path are
+  excluded from loop detection. An input path is relay-allowed when the
+  input mapping appears in at least one output mapping&rsquo;s
+  <strong>Relay from&hellip;</strong> list (&sect;7.2 for Serial, &sect;7.5
+  for MIDI). This means deliberately relayed traffic &mdash; e.g. a MIDI
+  input on one device being replayed on a MIDI output on a different
+  device &mdash; will not trigger the loop detector, even if the same
+  callsign or character sequence is sent repeatedly.
 </p>
 
 <h3>Avoiding Loops</h3>

--- a/src/app/components/midi-output-edit-modal/midi-output-edit-modal.component.css
+++ b/src/app/components/midi-output-edit-modal/midi-output-edit-modal.component.css
@@ -178,6 +178,12 @@
   padding: 0.2rem 0;
 }
 
+.midi-edit-warning {
+  color: #da0;
+  font-size: 0.82rem;
+  padding: 0.2rem 0;
+}
+
 /* Test mapping button */
 .test-mapping-btn {
   background: #1e3a4e;

--- a/src/app/components/midi-output-edit-modal/midi-output-edit-modal.component.html
+++ b/src/app/components/midi-output-edit-modal/midi-output-edit-modal.component.html
@@ -15,7 +15,7 @@
       <!-- MIDI Device -->
       <div class="midi-edit-field">
         <label class="midi-edit-label" for="midiOutEditDevice">MIDI Device</label>
-        <select id="midiOutEditDevice" class="midi-edit-select" [(ngModel)]="editDeviceId">
+        <select id="midiOutEditDevice" class="midi-edit-select" [(ngModel)]="editDeviceId" (ngModelChange)="updateWarning()">
           <option value="">Any (first available)</option>
           @for (dev of midiDevices; track dev.id) {
             <option [value]="dev.id">{{ dev.name }}</option>
@@ -26,7 +26,7 @@
       <!-- MIDI Channel -->
       <div class="midi-edit-field">
         <label class="midi-edit-label" for="midiOutEditChannel">MIDI Channel</label>
-        <select id="midiOutEditChannel" class="midi-edit-select" [(ngModel)]="editChannel">
+        <select id="midiOutEditChannel" class="midi-edit-select" [(ngModel)]="editChannel" (ngModelChange)="updateWarning()">
           @for (ch of midiChannels; track ch) {
             <option [ngValue]="ch">Channel {{ ch }}</option>
           }
@@ -46,7 +46,7 @@
       <!-- Mode (Straight Key / Paddle) -->
       <div class="midi-edit-field">
         <label class="midi-edit-label" for="midiOutEditMode">Mode</label>
-        <select id="midiOutEditMode" class="midi-edit-select" [(ngModel)]="editMode">
+        <select id="midiOutEditMode" class="midi-edit-select" [(ngModel)]="editMode" (ngModelChange)="updateWarning()">
           <option value="straightKey">Straight Key</option>
           <option value="paddle">Paddle</option>
         </select>
@@ -101,6 +101,42 @@
       <!-- Error -->
       @if (error) {
         <div class="midi-edit-error">{{ error }}</div>
+      }
+      @if (warning && !error) {
+        <div class="midi-edit-warning">{{ warning }}</div>
+      }
+
+      <!-- Relay from MIDI Input -->
+      @if (midiInputMappings.length > 0) {
+        <div class="midi-edit-field">
+          <label class="midi-edit-label">Relay from MIDI Input</label>
+          <div class="midi-edit-hint" style="margin-bottom: 6px">
+            Select MIDI input mappings to relay through this output. Only inputs
+            whose source matches the forward direction are shown.
+            Enable when input and output use separate hardware with no shared bus.
+          </div>
+          @for (input of midiInputMappings; track $index) {
+            @if (isInputCompatible(input)) {
+              <label class="midi-edit-checkbox-row" [class.midi-mapping-row-disabled]="!input.enabled">
+                <input type="checkbox"
+                       [checked]="editRelayInputIndices.includes($index)"
+                       (change)="toggleRelayInput($index)">
+                {{ inputMappingLabel(input, $index) }}
+              </label>
+            }
+          }
+          @if (editRelayInputIndices.length > 0) {
+            <label class="midi-edit-checkbox-row" style="margin-top: 6px">
+              <input type="checkbox" [(ngModel)]="editRelaySuppressOtherInputs">
+              Suppress other inputs
+            </label>
+            <div class="midi-edit-hint">
+              When enabled, this output will only forward signals from the
+              explicitly selected relay sources above. All other input paths
+              are suppressed.
+            </div>
+          }
+        </div>
       }
 
       <!-- Test button -->

--- a/src/app/components/midi-output-edit-modal/midi-output-edit-modal.component.ts
+++ b/src/app/components/midi-output-edit-modal/midi-output-edit-modal.component.ts
@@ -4,7 +4,7 @@
 
 import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MidiOutputMapping, MidiOutputMode, OutputForward } from '../../services/settings.service';
+import { MidiOutputMapping, MidiOutputMode, MidiInputMapping, OutputForward } from '../../services/settings.service';
 import { MidiOutputService, midiOutputNoteName } from '../../services/midi-output.service';
 
 /**
@@ -17,6 +17,8 @@ export interface MidiOutputEditSaveEvent {
   mode: MidiOutputMode;
   value: number;
   dahValue: number;
+  relayInputIndices: number[];
+  relaySuppressOtherInputs: boolean;
 }
 
 /**
@@ -40,7 +42,8 @@ export class MidiOutputEditModalComponent implements OnInit {
   /** The mapping being edited (used to populate initial values) */
   @Input() mapping: MidiOutputMapping = {
     enabled: true, deviceId: '', channel: 1,
-    forward: 'tx', mode: 'straightKey', value: 80, dahValue: -1,
+    forward: 'tx', mode: 'straightKey', value: 80, dahValue: -1, relayInputIndices: [],
+    relaySuppressOtherInputs: false,
   };
 
   /** Index of the mapping being edited (-1 for new) */
@@ -51,6 +54,9 @@ export class MidiOutputEditModalComponent implements OnInit {
 
   /** All existing mappings — used for duplicate detection */
   @Input() allMappings: MidiOutputMapping[] = [];
+
+  /** All MIDI input mappings — used for relay source selection */
+  @Input() midiInputMappings: MidiInputMapping[] = [];
 
   /** Emitted when the user saves the mapping */
   @Output() saved = new EventEmitter<MidiOutputEditSaveEvent>();
@@ -73,6 +79,12 @@ export class MidiOutputEditModalComponent implements OnInit {
   editValueRaw = '80';
   editDahValueRaw = '84';
 
+  /** Relay: indices of MIDI input mappings to relay through this output */
+  editRelayInputIndices: number[] = [];
+
+  /** When true, only relay sources drive this output */
+  editRelaySuppressOtherInputs = false;
+
   /** Tracked note-name index and octave for dropdowns */
   editValueNote = 0;
   editValueOctave = 4;
@@ -81,6 +93,9 @@ export class MidiOutputEditModalComponent implements OnInit {
 
   /** Validation error message */
   error = '';
+
+  /** Non-blocking warning (e.g. duplicate note) */
+  warning = '';
 
   /** Note names for dropdown */
   readonly noteNames = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
@@ -106,7 +121,11 @@ export class MidiOutputEditModalComponent implements OnInit {
     this.editValueOctave = this.getOctave(this.editValue);
     this.editDahNote = this.getNoteIndex(this.editDahValue);
     this.editDahOctave = this.getOctave(this.editDahValue);
+    this.editRelayInputIndices = [...(this.mapping.relayInputIndices || [])];
+    this.editRelaySuppressOtherInputs = this.mapping.relaySuppressOtherInputs ?? false;
     this.error = '';
+    this.warning = '';
+    this.updateWarning();
   }
 
   /** Get the note name component (0-11) from a MIDI note number */
@@ -134,12 +153,14 @@ export class MidiOutputEditModalComponent implements OnInit {
   onValueNoteChange(): void {
     this.editValue = this.clampMidi(this.toMidiNote(this.editValueNote, this.editValueOctave));
     this.editValueRaw = String(this.editValue);
+    this.updateWarning();
   }
 
   /** Handle octave dropdown change for value field */
   onValueOctaveChange(): void {
     this.editValue = this.clampMidi(this.toMidiNote(this.editValueNote, this.editValueOctave));
     this.editValueRaw = String(this.editValue);
+    this.updateWarning();
   }
 
   /** Handle raw MIDI value input for value field */
@@ -150,18 +171,21 @@ export class MidiOutputEditModalComponent implements OnInit {
       this.editValueNote = this.getNoteIndex(v);
       this.editValueOctave = this.getOctave(v);
     }
+    this.updateWarning();
   }
 
   /** Handle note name dropdown change for dah value field */
   onDahNoteChange(): void {
     this.editDahValue = this.clampMidi(this.toMidiNote(this.editDahNote, this.editDahOctave));
     this.editDahValueRaw = String(this.editDahValue);
+    this.updateWarning();
   }
 
   /** Handle octave dropdown change for dah value field */
   onDahOctaveChange(): void {
     this.editDahValue = this.clampMidi(this.toMidiNote(this.editDahNote, this.editDahOctave));
     this.editDahValueRaw = String(this.editDahValue);
+    this.updateWarning();
   }
 
   /** Handle raw MIDI value input for dah value field */
@@ -172,6 +196,7 @@ export class MidiOutputEditModalComponent implements OnInit {
       this.editDahNote = this.getNoteIndex(v);
       this.editDahOctave = this.getOctave(v);
     }
+    this.updateWarning();
   }
 
   /** Test this mapping — sends a 1-second pulse on the configured note(s) */
@@ -203,13 +228,6 @@ export class MidiOutputEditModalComponent implements OnInit {
       return;
     }
 
-    // Duplicate detection: device + channel + note must be unique
-    const dupError = this.checkDuplicates(value, dahValue);
-    if (dupError) {
-      this.error = dupError;
-      return;
-    }
-
     this.saved.emit({
       deviceId: this.editDeviceId,
       channel: this.editChannel,
@@ -217,6 +235,8 @@ export class MidiOutputEditModalComponent implements OnInit {
       mode: this.editMode,
       value,
       dahValue,
+      relayInputIndices: this.editRelayInputIndices,
+      relaySuppressOtherInputs: this.editRelaySuppressOtherInputs,
     });
   }
 
@@ -227,7 +247,7 @@ export class MidiOutputEditModalComponent implements OnInit {
    *
    * Two notes conflict when they share the same MIDI note number AND their
    * device/channel filters overlap (both 'any', or same specific device; both
-   * same channel).
+   * same channel). Returns a warning message or empty string.
    */
   private checkDuplicates(value: number, dahValue: number): string {
     const myNotes = [value];
@@ -252,7 +272,7 @@ export class MidiOutputEditModalComponent implements OnInit {
 
       for (const n of myNotes) {
         if (otherNotes.includes(n)) {
-          return `Note ${midiOutputNoteName(n)} (${n}) conflicts with mapping #${i + 1}. Use a different device, channel, or note.`;
+          return `Note ${midiOutputNoteName(n)} (${n}) overlaps with mapping #${i + 1} on the same device and channel. This is allowed but may cause unexpected behaviour if both mappings fire simultaneously.`;
         }
       }
     }
@@ -272,5 +292,34 @@ export class MidiOutputEditModalComponent implements OnInit {
   /** Clamp a MIDI note to valid range */
   private clampMidi(n: number): number {
     return Math.max(0, Math.min(127, n));
+  }
+
+  /** Recompute the non-blocking duplicate warning */
+  updateWarning(): void {
+    const dahValue = this.editMode === 'paddle' ? this.editDahValue : -1;
+    this.warning = this.checkDuplicates(this.editValue, dahValue);
+  }
+
+  /** Whether a MIDI input mapping's source is compatible with the output forward setting */
+  isInputCompatible(input: MidiInputMapping): boolean {
+    return this.editForward === 'both' || input.source === this.editForward;
+  }
+
+  /** Toggle a MIDI input mapping index in the relay list */
+  toggleRelayInput(index: number): void {
+    const pos = this.editRelayInputIndices.indexOf(index);
+    if (pos >= 0) {
+      this.editRelayInputIndices.splice(pos, 1);
+    } else {
+      this.editRelayInputIndices.push(index);
+    }
+  }
+
+  /** Short label for a MIDI input mapping */
+  inputMappingLabel(m: MidiInputMapping, index: number): string {
+    const mode = m.mode === 'straightKey' ? 'Straight' : 'Paddle';
+    const note = m.value >= 0 ? midiOutputNoteName(m.value) : '—';
+    const src = m.source.toUpperCase();
+    return `#${index + 1} ${mode} ${note} [${src}]`;
   }
 }

--- a/src/app/components/serial-output-edit-modal/serial-output-edit-modal.component.css
+++ b/src/app/components/serial-output-edit-modal/serial-output-edit-modal.component.css
@@ -127,6 +127,12 @@
   padding: 0.2rem 0;
 }
 
+.serial-edit-warning {
+  color: #da0;
+  font-size: 0.82rem;
+  padding: 0.2rem 0;
+}
+
 .serial-edit-checkbox-row label {
   display: flex;
   align-items: center;

--- a/src/app/components/serial-output-edit-modal/serial-output-edit-modal.component.html
+++ b/src/app/components/serial-output-edit-modal/serial-output-edit-modal.component.html
@@ -37,7 +37,7 @@
       <!-- Output Pin (DTR / RTS) -->
       <div class="serial-edit-field">
         <label class="serial-edit-label" for="serialOutEditPin">Output Pin</label>
-        <select id="serialOutEditPin" class="serial-edit-select" [(ngModel)]="editPin">
+        <select id="serialOutEditPin" class="serial-edit-select" [(ngModel)]="editPin" (ngModelChange)="updateWarning()">
           @for (p of pins; track p.value) {
             <option [value]="p.value">{{ p.label }}</option>
           }
@@ -70,6 +70,42 @@
       <!-- Error -->
       @if (error) {
         <div class="serial-edit-error">{{ error }}</div>
+      }
+      @if (warning && !error) {
+        <div class="serial-edit-warning">{{ warning }}</div>
+      }
+
+      <!-- Relay from Serial Input -->
+      @if (serialInputMappings.length > 0) {
+        <div class="serial-edit-field">
+          <label class="serial-edit-label">Relay from Serial Input</label>
+          <span class="serial-edit-hint" style="margin-bottom: 6px">
+            Select serial input mappings to relay through this output. Only inputs
+            whose source matches the forward direction are shown.
+            Enable when input and output use separate adapters or ports with no electrical connection.
+          </span>
+          @for (input of serialInputMappings; track $index) {
+            @if (isInputCompatible(input)) {
+              <label class="serial-edit-checkbox-row" [class.midi-mapping-row-disabled]="!input.enabled">
+                <input type="checkbox"
+                       [checked]="editRelayInputIndices.includes($index)"
+                       (change)="toggleRelayInput($index)">
+                {{ inputMappingLabel(input, $index) }}
+              </label>
+            }
+          }
+          @if (editRelayInputIndices.length > 0) {
+            <label class="serial-edit-checkbox-row" style="margin-top: 6px">
+              <input type="checkbox" [(ngModel)]="editRelaySuppressOtherInputs">
+              Suppress other inputs
+            </label>
+            <span class="serial-edit-hint">
+              When enabled, this output will only forward signals from the
+              explicitly selected relay sources above. All other input paths
+              are suppressed.
+            </span>
+          }
+        </div>
       }
 
       <!-- Test (only for existing mappings with connected port) -->

--- a/src/app/components/serial-output-edit-modal/serial-output-edit-modal.component.ts
+++ b/src/app/components/serial-output-edit-modal/serial-output-edit-modal.component.ts
@@ -4,7 +4,7 @@
 
 import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { SerialOutputMapping, SerialPin, OutputForward } from '../../services/settings.service';
+import { SerialOutputMapping, SerialInputMapping, SerialPin, OutputForward } from '../../services/settings.service';
 import { SerialKeyOutputService } from '../../services/serial-key-output.service';
 
 /**
@@ -15,6 +15,8 @@ export interface SerialOutputEditSaveEvent {
   pin: SerialPin;
   invert: boolean;
   forward: OutputForward;
+  relayInputIndices: number[];
+  relaySuppressOtherInputs: boolean;
 }
 
 /**
@@ -34,7 +36,8 @@ export interface SerialOutputEditSaveEvent {
 export class SerialOutputEditModalComponent implements OnInit {
   /** The mapping being edited (used to populate initial values) */
   @Input() mapping: SerialOutputMapping = {
-    enabled: true, portIndex: -1, pin: 'dtr', invert: false, forward: 'tx',
+    enabled: true, portIndex: -1, pin: 'dtr', invert: false, forward: 'tx', relayInputIndices: [],
+    relaySuppressOtherInputs: false,
   };
 
   /** Index of the mapping being edited (-1 for new) */
@@ -42,6 +45,9 @@ export class SerialOutputEditModalComponent implements OnInit {
 
   /** All existing mappings — used for duplicate detection */
   @Input() allMappings: SerialOutputMapping[] = [];
+
+  /** All serial input mappings — used for relay source selection */
+  @Input() serialInputMappings: SerialInputMapping[] = [];
 
   /** Reference to the serial output service (for ports, connected state) */
   @Input() serialOutput!: SerialKeyOutputService;
@@ -61,8 +67,17 @@ export class SerialOutputEditModalComponent implements OnInit {
   editInvert = false;
   editForward: OutputForward = 'tx';
 
+  /** Relay: indices of serial input mappings to relay through this output */
+  editRelayInputIndices: number[] = [];
+
+  /** When true, only relay sources drive this output */
+  editRelaySuppressOtherInputs = false;
+
   /** Validation error message */
   error = '';
+
+  /** Non-blocking warning (e.g. duplicate port+pin) */
+  warning = '';
 
   /** Available output pins */
   readonly pins: { value: SerialPin; label: string }[] = [
@@ -75,7 +90,11 @@ export class SerialOutputEditModalComponent implements OnInit {
     this.editPin = this.mapping.pin;
     this.editInvert = this.mapping.invert;
     this.editForward = this.mapping.forward;
+    this.editRelayInputIndices = [...(this.mapping.relayInputIndices || [])];
+    this.editRelaySuppressOtherInputs = this.mapping.relaySuppressOtherInputs ?? false;
     this.error = '';
+    this.warning = '';
+    this.updateWarning();
   }
 
   /** Whether the selected port is currently connected */
@@ -92,22 +111,18 @@ export class SerialOutputEditModalComponent implements OnInit {
       return;
     }
     this.editPortIndex = parseInt(select.value, 10);
+    this.updateWarning();
   }
 
   /** Save the edited mapping after validation */
   save(): void {
-    // Duplicate detection: same port + same pin on another mapping
-    const dupError = this.checkDuplicates();
-    if (dupError) {
-      this.error = dupError;
-      return;
-    }
-
     this.saved.emit({
       portIndex: this.editPortIndex,
       pin: this.editPin,
       invert: this.editInvert,
       forward: this.editForward,
+      relayInputIndices: this.editRelayInputIndices,
+      relaySuppressOtherInputs: this.editRelaySuppressOtherInputs,
     });
   }
 
@@ -121,14 +136,14 @@ export class SerialOutputEditModalComponent implements OnInit {
     this.deleted.emit();
   }
 
-  /** Check for duplicate port+pin combinations */
+  /** Check for duplicate port+pin combinations (non-blocking warning) */
   private checkDuplicates(): string | null {
     if (this.editPortIndex < 0) return null;
     for (let i = 0; i < this.allMappings.length; i++) {
       if (i === this.editIndex) continue;
       const m = this.allMappings[i];
       if (m.portIndex === this.editPortIndex && m.pin === this.editPin) {
-        return `Another mapping already uses ${this.editPin.toUpperCase()} on this port.`;
+        return `Another mapping (#${i + 1}) also uses ${this.editPin.toUpperCase()} on this port. This is allowed but may cause unexpected behaviour if both mappings fire simultaneously.`;
       }
     }
     return null;
@@ -138,5 +153,34 @@ export class SerialOutputEditModalComponent implements OnInit {
   async testOutput(): Promise<void> {
     if (this.editIndex < 0 || !this.isConnected) return;
     await this.serialOutput.test(this.editIndex);
+  }
+
+  /** Recompute the non-blocking duplicate warning */
+  updateWarning(): void {
+    this.warning = this.checkDuplicates() ?? '';
+  }
+
+  /** Whether a serial input mapping's source is compatible with the output forward setting */
+  isInputCompatible(input: SerialInputMapping): boolean {
+    return this.editForward === 'both' || input.source === this.editForward;
+  }
+
+  /** Toggle a serial input mapping index in the relay list */
+  toggleRelayInput(index: number): void {
+    const pos = this.editRelayInputIndices.indexOf(index);
+    if (pos >= 0) {
+      this.editRelayInputIndices.splice(pos, 1);
+    } else {
+      this.editRelayInputIndices.push(index);
+    }
+  }
+
+  /** Short label for a serial input mapping */
+  inputMappingLabel(m: SerialInputMapping, index: number): string {
+    const mode = m.mode === 'straightKey' ? 'Straight' : 'Paddle';
+    const pin = m.pin.toUpperCase();
+    const src = m.source.toUpperCase();
+    const name = m.name ? ` (${m.name})` : '';
+    return `#${index + 1} ${mode} ${pin} [${src}]${name}`;
   }
 }

--- a/src/app/components/settings-modal/settings-inputs-tab/midi-input-card/midi-input-card.component.ts
+++ b/src/app/components/settings-modal/settings-inputs-tab/midi-input-card/midi-input-card.component.ts
@@ -152,7 +152,15 @@ export class MidiInputCardComponent {
   onEditDeleted(): void {
     if (this.editIndex >= 0) {
       const mappings = this.settings.settings().midiInputMappings.filter((_, i) => i !== this.editIndex);
-      this.settings.update({ midiInputMappings: mappings });
+      // Clean up relay references in output mappings: remove the deleted index
+      // and decrement any index greater than the deleted one.
+      const outputMappings = this.settings.settings().midiOutputMappings.map(om => ({
+        ...om,
+        relayInputIndices: om.relayInputIndices
+          .filter(idx => idx !== this.editIndex)
+          .map(idx => idx > this.editIndex ? idx - 1 : idx),
+      }));
+      this.settings.update({ midiInputMappings: mappings, midiOutputMappings: outputMappings });
       this.midiInput.reattach();
     }
     this.showEditModal = false;

--- a/src/app/components/settings-modal/settings-inputs-tab/serial-input-card/serial-input-card.component.ts
+++ b/src/app/components/settings-modal/settings-inputs-tab/serial-input-card/serial-input-card.component.ts
@@ -164,7 +164,15 @@ export class SerialInputCardComponent {
   onEditDeleted(): void {
     if (this.editIndex >= 0) {
       const mappings = this.settings.settings().serialInputMappings.filter((_, i) => i !== this.editIndex);
-      this.settings.update({ serialInputMappings: mappings });
+      // Clean up relay references in output mappings: remove the deleted index
+      // and decrement any index greater than the deleted one.
+      const outputMappings = this.settings.settings().serialOutputMappings.map(om => ({
+        ...om,
+        relayInputIndices: om.relayInputIndices
+          .filter(idx => idx !== this.editIndex)
+          .map(idx => idx > this.editIndex ? idx - 1 : idx),
+      }));
+      this.settings.update({ serialInputMappings: mappings, serialOutputMappings: outputMappings });
     }
     this.showEditModal = false;
   }

--- a/src/app/components/settings-modal/settings-outputs-tab/midi-output-card/midi-output-card.component.html
+++ b/src/app/components/settings-modal/settings-outputs-tab/midi-output-card/midi-output-card.component.html
@@ -86,6 +86,7 @@
     [editIndex]="editIndex"
     [midiDevices]="midiOutput.midiOutputs()"
     [allMappings]="settings.settings().midiOutputMappings"
+    [midiInputMappings]="settings.settings().midiInputMappings"
     (saved)="onEditSaved($event)"
     (cancelled)="onEditCancelled()"
     (deleted)="onEditDeleted()">

--- a/src/app/components/settings-modal/settings-outputs-tab/midi-output-card/midi-output-card.component.ts
+++ b/src/app/components/settings-modal/settings-outputs-tab/midi-output-card/midi-output-card.component.ts
@@ -33,7 +33,8 @@ export class MidiOutputCardComponent {
   /** Scratch copy of the mapping passed to the edit modal */
   editMapping: MidiOutputMapping = {
     enabled: true, deviceId: '', channel: 1,
-    forward: 'tx', mode: 'straightKey', value: 80, dahValue: -1,
+    forward: 'tx', mode: 'straightKey', value: 80, dahValue: -1, relayInputIndices: [],
+    relaySuppressOtherInputs: false,
   };
 
   /** Whether the edit modal is visible */
@@ -89,7 +90,8 @@ export class MidiOutputCardComponent {
     this.editIndex = -1;
     this.editMapping = {
       enabled: true, deviceId: '', channel: 1,
-      forward: 'tx', mode: 'straightKey', value: 80, dahValue: -1,
+      forward: 'tx', mode: 'straightKey', value: 80, dahValue: -1, relayInputIndices: [],
+      relaySuppressOtherInputs: false,
     };
     this.showEditModal = true;
     this.ensureDevicesEnumerated();
@@ -107,6 +109,8 @@ export class MidiOutputCardComponent {
         mode: event.mode,
         value: event.value,
         dahValue: event.dahValue,
+        relayInputIndices: event.relayInputIndices,
+        relaySuppressOtherInputs: event.relaySuppressOtherInputs,
       };
     } else {
       mappings.push({
@@ -117,6 +121,8 @@ export class MidiOutputCardComponent {
         mode: event.mode,
         value: event.value,
         dahValue: event.dahValue,
+        relayInputIndices: event.relayInputIndices,
+        relaySuppressOtherInputs: event.relaySuppressOtherInputs,
       });
     }
     this.settings.update({ midiOutputMappings: mappings });

--- a/src/app/components/settings-modal/settings-outputs-tab/rtdb-output-card/rtdb-output-card.component.html
+++ b/src/app/components/settings-modal/settings-outputs-tab/rtdb-output-card/rtdb-output-card.component.html
@@ -84,6 +84,38 @@
       </label>
       <div class="cw-hint">When unchecked, input-specific colors are sent if defined; otherwise this color is used as fallback.</div>
 
+      <label class="checkbox-label">
+        <input type="checkbox" [checked]="settings.settings().rtdbAllowInputRelay && !isSameChannel()"
+               [disabled]="isSameChannel()"
+               (change)="onBoolChange('rtdbAllowInputRelay', $event)">
+        Allow relay from RTDB input to RTDB output
+      </label>
+      @if (isSameChannel()) {
+        <div class="cw-hint">
+          Relay is not available when input and output use the same channel and
+          secret, as this would create a feedback loop.
+        </div>
+      } @else {
+        <div class="cw-hint">
+          Enable when RTDB input and output use different channel/secret
+          combinations. Characters received on the input channel will be
+          relayed to the output channel.
+        </div>
+      }
+
+      @if (settings.settings().rtdbAllowInputRelay && !isSameChannel()) {
+        <label class="checkbox-label">
+          <input type="checkbox" [checked]="settings.settings().rtdbRelaySuppressOtherInputs"
+                 (change)="onBoolChange('rtdbRelaySuppressOtherInputs', $event)">
+          Suppress other inputs
+        </label>
+        <div class="cw-hint">
+          When enabled, only characters received from the RTDB input channel
+          are forwarded to RTDB output. All other local input paths are
+          suppressed.
+        </div>
+      }
+
       <div class="cw-hint">
         Publishes decoded morse characters to a Firebase Realtime Database channel.
         Remote stations subscribed to the same channel and secret will receive

--- a/src/app/components/settings-modal/settings-outputs-tab/rtdb-output-card/rtdb-output-card.component.ts
+++ b/src/app/components/settings-modal/settings-outputs-tab/rtdb-output-card/rtdb-output-card.component.ts
@@ -2,7 +2,7 @@
  * Morse Code Studio
  */
 
-import { Component, OnDestroy } from '@angular/core';
+import { Component, OnDestroy, computed } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { SettingsService, AppSettings } from '../../../../services/settings.service';
 import { FirebaseRtdbService } from '../../../../services/firebase-rtdb.service';
@@ -27,6 +27,18 @@ export class RtdbOutputCardComponent implements OnDestroy {
 
   /** Debounce timer for RTDB output restart on text field changes */
   private rtdbOutputDebounce: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * True when the RTDB input and output share the same non-empty channel
+   * name and secret — relay must be disabled to prevent a feedback loop.
+   */
+  readonly isSameChannel = computed(() => {
+    const s = this.settings.settings();
+    const inCh = s.rtdbInputChannelName.trim();
+    const outCh = s.rtdbOutputChannelName.trim();
+    return !!(inCh && outCh && inCh === outCh
+      && s.rtdbInputChannelSecret.trim() === s.rtdbOutputChannelSecret.trim());
+  });
 
   constructor(
     public settings: SettingsService,

--- a/src/app/components/settings-modal/settings-outputs-tab/serial-output-card/serial-output-card.component.html
+++ b/src/app/components/settings-modal/settings-outputs-tab/serial-output-card/serial-output-card.component.html
@@ -88,6 +88,7 @@
     [mapping]="editMapping"
     [editIndex]="editIndex"
     [allMappings]="settings.settings().serialOutputMappings"
+    [serialInputMappings]="settings.settings().serialInputMappings"
     [serialOutput]="serialOutput"
     (saved)="onEditSaved($event)"
     (cancelled)="onEditCancelled()"

--- a/src/app/components/settings-modal/settings-outputs-tab/serial-output-card/serial-output-card.component.ts
+++ b/src/app/components/settings-modal/settings-outputs-tab/serial-output-card/serial-output-card.component.ts
@@ -31,7 +31,8 @@ export class SerialOutputCardComponent {
 
   /** Scratch copy of the mapping passed to the edit modal */
   editMapping: SerialOutputMapping = {
-    enabled: true, portIndex: -1, pin: 'dtr', invert: false, forward: 'tx',
+    enabled: true, portIndex: -1, pin: 'dtr', invert: false, forward: 'tx', relayInputIndices: [],
+    relaySuppressOtherInputs: false,
   };
 
   /** Whether the edit modal is visible */
@@ -103,7 +104,8 @@ export class SerialOutputCardComponent {
   addMapping(): void {
     this.editIndex = -1;
     this.editMapping = {
-      enabled: true, portIndex: -1, pin: 'dtr', invert: false, forward: 'tx',
+      enabled: true, portIndex: -1, pin: 'dtr', invert: false, forward: 'tx', relayInputIndices: [],
+      relaySuppressOtherInputs: false,
     };
     this.showEditModal = true;
     this.serialOutput.refreshPorts();
@@ -119,6 +121,8 @@ export class SerialOutputCardComponent {
         pin: event.pin,
         invert: event.invert,
         forward: event.forward,
+        relayInputIndices: event.relayInputIndices,
+        relaySuppressOtherInputs: event.relaySuppressOtherInputs,
       };
     } else {
       mappings.push({
@@ -127,6 +131,8 @@ export class SerialOutputCardComponent {
         pin: event.pin,
         invert: event.invert,
         forward: event.forward,
+        relayInputIndices: event.relayInputIndices,
+        relaySuppressOtherInputs: event.relaySuppressOtherInputs,
       });
     }
     this.settings.update({ serialOutputMappings: mappings });

--- a/src/app/services/firebase-rtdb.service.ts
+++ b/src/app/services/firebase-rtdb.service.ts
@@ -534,7 +534,7 @@ export class FirebaseRtdbService implements OnDestroy {
    * @param source Whether this came from 'rx' or 'tx' decoder pool
    * @param wpm    WPM speed used to generate this character
    */
-  async forwardDecodedChar(char: string, source: 'rx' | 'tx', wpm?: number, inputName?: string, inputColor?: string): Promise<void> {
+  async forwardDecodedChar(char: string, source: 'rx' | 'tx', wpm?: number, inputName?: string, inputColor?: string, isRelay = false): Promise<void> {
     if (!this.settings.settings().rtdbOutputEnabled) return;
     if (!this.outputActive()) return;
     if (!this.db) return;
@@ -574,8 +574,13 @@ export class FirebaseRtdbService implements OnDestroy {
         wpm: wpm ?? s.encoderWpm,
       };
       if (effectiveColor) entry['col'] = effectiveColor;
-      // Track the name before writing — onValue fires synchronously on local set()
-      this.sentNames.add(effectiveName);
+      // Track the name before writing — onValue fires synchronously on local set().
+      // Skip for relay: the sender name belongs to a remote party on the input
+      // channel. Adding it to sentNames would suppress the next message from the
+      // same sender, breaking relay of consecutive characters.
+      if (!isRelay) {
+        this.sentNames.add(effectiveName);
+      }
       await set(entryRef, entry);
     } catch (err: any) {
       // Don't spam errors for every character — just set once

--- a/src/app/services/midi-input.service.ts
+++ b/src/app/services/midi-input.service.ts
@@ -412,28 +412,19 @@ export class MidiInputService implements OnDestroy {
     if (!this.settings.settings().midiInputEnabled) return;
 
     // ======================================================================
-    // *** DO NOT CHANGE THIS CHECK TO PER-NOTE OR ANY OTHER VARIATION ***
+    // Blanket isSending() suppression prevents physical bus echoes: when
+    // the MIDI output sends ANY note, the common bus is energised and
+    // hardware simultaneously mirrors the signal on the input.
     //
-    // Blanket isSending() suppression is REQUIRED because MIDI notes are
-    // converted to electrical signals on a COMMON PHYSICAL BUS where both
-    // sending and receiving happen on the same wire.  When the MIDI output
-    // sends ANY note, the bus is energised and the MIDI input hardware
-    // simultaneously samples the same bus, generating a mirror note-on.
-    // The note numbers are LOST in the electrical domain — only "bus
-    // active / bus idle" matters.  Therefore we must mute ALL MIDI input
-    // while ANY MIDI output note is held, regardless of note number.
+    // The check is moved INTO the per-mapping loop so that input mappings
+    // that are explicitly configured as relay sources (referenced by at
+    // least one output mapping's relayInputIndices) bypass the isSending
+    // gate — the user has asserted those inputs are on separate hardware.
     //
-    // True parallel operation (e.g. receiving MIDI while the keyboard
-    // keyer is active) is achieved by:
-    //  1. Real-time MIDI output keying in the decoder (keyDown/keyUp),
-    //     which keeps isSending() true only during actual key-down —
-    //     not during the decoder's word-gap silence timers.
-    //  2. Not forwarding local-keyer decoded characters to MIDI output
-    //     via forwardDecodedChar (they are already keyed in real-time).
-    //  3. This service bypassing KeyerService entirely (own iambic keyer
-    //     + direct decoder calls), so no shared state with keyboard.
+    // Non-relay input mappings are still blanket-muted while ANY output
+    // note is held, regardless of note number.
     // ======================================================================
-    if (isNoteOn && this.midiOutput.isSending()) return;
+    const sending = isNoteOn && this.midiOutput.isSending();
 
     // Note-off: use stored action state
     if (isNoteOff) {
@@ -463,6 +454,7 @@ export class MidiInputService implements OnDestroy {
     // Note-on: find matching mapping
     const deviceId = (msg.target as MIDIInput | null)?.id || '';
     const mappings = this.settings.settings().midiInputMappings;
+    const outputMappings = this.settings.settings().midiOutputMappings;
 
     for (let mi = 0; mi < mappings.length; mi++) {
       const mapping = mappings[mi];
@@ -471,6 +463,10 @@ export class MidiInputService implements OnDestroy {
       if (mapping.deviceId && mapping.deviceId !== deviceId) continue;
       // Channel filter
       if (mapping.channel > 0 && mapping.channel !== channel) continue;
+
+      // Per-mapping isSending check: block physical bus echoes unless
+      // this input is a relay source for at least one output mapping.
+      if (sending && !outputMappings.some(om => om.enabled && om.relayInputIndices.includes(mi))) return;
 
       if (mapping.mode === 'straightKey' && note === mapping.value) {
         this.activeNotes.set(note, { action: 'straightKey', source: mapping.source, name: mapping.name || '', color: mapping.color || '', mappingIndex: mi });

--- a/src/app/services/midi-output.service.ts
+++ b/src/app/services/midi-output.service.ts
@@ -133,7 +133,7 @@ export class MidiOutputService implements OnDestroy {
   private activeNotes = new Map<string, { note: number; channel: number; output: MIDIOutput }>();
 
   /** Character playback queue */
-  private charQueue: { char: string; source: 'rx' | 'tx'; wpm?: number; paddleOnly?: boolean }[] = [];
+  private charQueue: { char: string; source: 'rx' | 'tx'; wpm?: number; paddleOnly?: boolean; isFromRelay?: boolean }[] = [];
   private playing = false;
   private abortPlayback = false;
 
@@ -323,11 +323,11 @@ export class MidiOutputService implements OnDestroy {
    *                   mappings are skipped (they are already keyed in real-time
    *                   via the keyDown/keyUp path for local keyer inputs).
    */
-  forwardDecodedChar(char: string, source: 'rx' | 'tx', wpm?: number, paddleOnly = false): void {
+  forwardDecodedChar(char: string, source: 'rx' | 'tx', wpm?: number, paddleOnly = false, isFromRelay = false): void {
     if (!this.isActive()) return;
     // During break-in the remote party has priority — drop outgoing chars.
     if (this.breakInActive) return;
-    this.charQueue.push({ char, source, wpm, paddleOnly });
+    this.charQueue.push({ char, source, wpm, paddleOnly, isFromRelay });
     // If we're sleeping through a word gap and a real character arrives,
     // cut the sleep short so the new character plays immediately.
     if (char !== ' ' && this.spaceSleepResolve) {
@@ -346,7 +346,7 @@ export class MidiOutputService implements OnDestroy {
     try {
       while (this.charQueue.length > 0 && !this.abortPlayback) {
         const entry = this.charQueue.shift()!;
-        await this.playCharElements(entry.char, entry.source, entry.wpm, entry.paddleOnly);
+        await this.playCharElements(entry.char, entry.source, entry.wpm, entry.paddleOnly, entry.isFromRelay);
       }
     } finally {
       this.playing = false;
@@ -360,7 +360,7 @@ export class MidiOutputService implements OnDestroy {
    * Uses the provided remote WPM if available and the override setting is off;
    * otherwise falls back to the local encoder WPM.
    */
-  private async playCharElements(char: string, source: 'rx' | 'tx', wpm?: number, paddleOnly = false): Promise<void> {
+  private async playCharElements(char: string, source: 'rx' | 'tx', wpm?: number, paddleOnly = false, isFromRelay = false): Promise<void> {
     const s0 = this.settings.settings();
     const effectiveWpm = (wpm && !s0.midiOutputOverrideWpm) ? wpm : s0.encoderWpm;
     const timings = timingsFromWpm(effectiveWpm);
@@ -378,9 +378,11 @@ export class MidiOutputService implements OnDestroy {
     // Collect enabled mappings whose forward filter matches the source.
     // When paddleOnly is set, skip straight-key mappings (they are already
     // keyed in real-time via keyDown/keyUp for local keyer inputs).
+    // When not from a relay source, skip mappings with relaySuppressOtherInputs.
     const enabledMappings = s.midiOutputMappings.filter(m =>
       m.enabled && (m.forward === 'both' || m.forward === source)
       && (!paddleOnly || m.mode === 'paddle')
+      && (isFromRelay || !m.relaySuppressOtherInputs)
     );
 
     for (let i = 0; i < morse.length; i++) {
@@ -462,14 +464,23 @@ export class MidiOutputService implements OnDestroy {
    * radio keying that matches the sidetone timing exactly, unlike the
    * character-based forwarding path which introduces decode delay.
    *
-   * Not called for MIDI-originated inputs (fromMidi) to prevent echo loops.
+   * Not called for MIDI-originated inputs (fromMidi) to prevent echo loops,
+   * unless relay is enabled for the specific input-output pair.
+   *
+   * @param source            Signal source ('rx' or 'tx')
+   * @param relayInputIndex   When provided, only fire output mappings whose
+   *                          relayInputIndices includes this index.
    */
-  keyDown(source: 'rx' | 'tx' = 'tx'): void {
+  keyDown(source: 'rx' | 'tx' = 'tx', relayInputIndex?: number): void {
     if (!this.isActive()) return;
     const s = this.settings.settings();
     const velocity = 127;
     for (const mapping of s.midiOutputMappings) {
-      if (!mapping.enabled || mapping.mode !== 'straightKey') continue;      if (mapping.forward !== 'both' && mapping.forward !== source) continue;      const output = this.getOutputForDevice(mapping.deviceId);
+      if (!mapping.enabled || mapping.mode !== 'straightKey') continue;
+      if (mapping.forward !== 'both' && mapping.forward !== source) continue;
+      if (relayInputIndex !== undefined && !mapping.relayInputIndices.includes(relayInputIndex)) continue;
+      if (relayInputIndex === undefined && mapping.relaySuppressOtherInputs) continue;
+      const output = this.getOutputForDevice(mapping.deviceId);
       if (!output || mapping.value < 0) continue;
       this.sendNoteOn(mapping.value, velocity, mapping.channel, output);
     }

--- a/src/app/services/morse-decoder.service.ts
+++ b/src/app/services/morse-decoder.service.ts
@@ -3,7 +3,7 @@
  */
 
 import { Injectable, signal } from '@angular/core';
-import { SettingsService, InputPath } from './settings.service';
+import { SettingsService, InputPath, OutputForward } from './settings.service';
 import { MORSE_REVERSE, timingsFromWpm } from '../morse-table';
 import { AudioOutputService } from './audio-output.service';
 import { SerialKeyOutputService } from './serial-key-output.service';
@@ -302,18 +302,38 @@ export class MorseDecoderService {
       // Serial output: local keyer pipelines only.
       // Receive pipelines must not key the radio — the received signal
       // may BE from that radio, so keying it would create a loop.
+      // Exception: when the user has enabled per-mapping relay from a
+      // specific serial input to specific serial output(s).
       if (!isReceive) {
         pipeline.activatedOutputs.add('serial');
         this.serialOutputRefCount++;
         this.serialOutput.keyDown(source);
+      } else if (pipeline.fromSerial) {
+        const idx = this.extractInputIndex(path, 'serial');
+        const outMappings = this.settings.settings().serialOutputMappings;
+        if (idx !== undefined && this.hasRelayOutput(outMappings, idx, source)) {
+          pipeline.activatedOutputs.add('serial');
+          this.serialOutputRefCount++;
+          this.serialOutput.keyDown(source, idx);
+        }
       }
 
       // MIDI output: local keyer pipelines only.
       // Receive pipelines must not echo onto the MIDI bus or radio chain.
+      // Exception: when the user has enabled per-mapping relay from a
+      // specific MIDI input to specific MIDI output(s).
       if (!isReceive) {
         pipeline.activatedOutputs.add('midi');
         this.midiOutputRefCount++;
         this.midiOutput.keyDown(source);
+      } else if (pipeline.fromMidi) {
+        const idx = this.extractInputIndex(path, 'midi');
+        const outMappings = this.settings.settings().midiOutputMappings;
+        if (idx !== undefined && this.hasRelayOutput(outMappings, idx, source)) {
+          pipeline.activatedOutputs.add('midi');
+          this.midiOutputRefCount++;
+          this.midiOutput.keyDown(source, idx);
+        }
       }
     }
   }
@@ -657,5 +677,26 @@ export class MorseDecoderService {
 
     const wpm = Math.round(1200 / medianDitMs);
     this.estimatedWpmSignalForSource(source).set(Math.max(1, Math.min(60, wpm)));
+  }
+
+  /** Extract the input mapping index from an InputPath string, e.g. 'midiStraightKey:2' → 2 */
+  private extractInputIndex(path: InputPath, prefix: 'midi' | 'serial'): number | undefined {
+    const m = path.match(prefix === 'midi'
+      ? /^midi(?:StraightKey|Paddle):(\d+)/
+      : /^serial(?:StraightKey|Paddle):(\d+)/);
+    return m ? parseInt(m[1], 10) : undefined;
+  }
+
+  /** Check whether any enabled output mapping relays from the given input index */
+  private hasRelayOutput(
+    mappings: readonly { enabled: boolean; forward: OutputForward; relayInputIndices: number[] }[],
+    inputIndex: number,
+    source: 'rx' | 'tx',
+  ): boolean {
+    return mappings.some(m =>
+      m.enabled
+      && (m.forward === 'both' || m.forward === source)
+      && m.relayInputIndices.includes(inputIndex),
+    );
   }
 }

--- a/src/app/services/serial-key-input.service.ts
+++ b/src/app/services/serial-key-input.service.ts
@@ -471,15 +471,7 @@ export class SerialKeyInputService implements OnDestroy {
     const s = this.settings.settings();
     if (!s.serialInputEnabled) return;
 
-    // ======================================================================
-    // *** DO NOT CHANGE THIS CHECK TO PER-PIN OR ANY OTHER VARIATION ***
-    //
-    // Blanket isSending() suppression is REQUIRED because serial output
-    // and serial input may share the SAME PHYSICAL PORT and adapter.
-    // When the serial output asserts DTR/RTS, some adapters (especially
-    // FTDI and CH340) can cross-talk between output pins and input pins
-    // due to shared ground references, cable coupling, or user wiring.
-    // ======================================================================
+    // ======================================================================\n    // Blanket isSending() suppression prevents cross-talk: serial output\n    // and serial input may share the SAME PHYSICAL PORT and adapter.\n    //\n    // The check is applied per-mapping: input mappings that are\n    // explicitly configured as relay sources (referenced by at least one\n    // output mapping's relayInputIndices) bypass the isSending gate.\n    // ======================================================================
 
     s.serialInputMappings.forEach((m, idx) => {
       if (!m.enabled || m.portIndex !== portIndex) return;
@@ -492,12 +484,21 @@ export class SerialKeyInputService implements OnDestroy {
     m: SerialInputMapping, mappingIndex: number,
     pin: SerialInputPin, value: boolean, oldValue: boolean,
   ): void {
+    // Per-mapping isSending check: block physical bus echoes unless
+    // this input mapping is a relay source for at least one output mapping.
+    const sending = this.serialOutput.isSending();
+    const isRelaySrc = sending
+      ? this.settings.settings().serialOutputMappings.some(
+          om => om.enabled && om.relayInputIndices.includes(mappingIndex),
+        )
+      : false;
+
     if (m.mode === 'straightKey') {
       if (pin === m.pin) {
         const effective = m.invert ? !value : value;
         const wasEffective = m.invert ? !oldValue : oldValue;
         if (effective !== wasEffective) {
-          if (effective && this.serialOutput.isSending()) return;
+          if (effective && sending && !isRelaySrc) return;
           this.handleStraightKey(mappingIndex, effective, m.source);
         }
       }
@@ -508,7 +509,7 @@ export class SerialKeyInputService implements OnDestroy {
         const effective = m.invert ? !value : value;
         const wasEffective = m.invert ? !oldValue : oldValue;
         if (effective !== wasEffective) {
-          if (effective && this.serialOutput.isSending()) return;
+          if (effective && sending && !isRelaySrc) return;
           if (reverse) {
             this.dahPaddleInput(mappingIndex, effective, m.source, m.paddleMode);
           } else {
@@ -520,7 +521,7 @@ export class SerialKeyInputService implements OnDestroy {
         const effective = m.invert ? !value : value;
         const wasEffective = m.invert ? !oldValue : oldValue;
         if (effective !== wasEffective) {
-          if (effective && this.serialOutput.isSending()) return;
+          if (effective && sending && !isRelaySrc) return;
           if (reverse) {
             this.ditPaddleInput(mappingIndex, effective, m.source, m.paddleMode);
           } else {

--- a/src/app/services/serial-key-output.service.ts
+++ b/src/app/services/serial-key-output.service.ts
@@ -192,9 +192,11 @@ export class SerialKeyOutputService {
 
   /**
    * Key down — drive active signal on all matching mappings.
-   * @param source  The signal source ('rx' or 'tx')
+   * @param source            The signal source ('rx' or 'tx')
+   * @param relayInputIndex   When provided, only fire output mappings whose
+   *                          relayInputIndices includes this index.
    */
-  keyDown(source: 'rx' | 'tx' = 'tx'): void {
+  keyDown(source: 'rx' | 'tx' = 'tx', relayInputIndex?: number): void {
     const s = this.settings.settings();
     if (!s.serialEnabled) return;
 
@@ -202,6 +204,8 @@ export class SerialKeyOutputService {
       const m = s.serialOutputMappings[i];
       if (!m.enabled || m.portIndex < 0) continue;
       if (m.forward !== 'both' && m.forward !== source) continue;
+      if (relayInputIndex !== undefined && !m.relayInputIndices.includes(relayInputIndex)) continue;
+      if (relayInputIndex === undefined && m.relaySuppressOtherInputs) continue;
 
       const ps = this.openPorts().get(m.portIndex);
       if (!ps) continue;

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -142,6 +142,10 @@ export interface MidiOutputMapping {
   value: number;
   /** MIDI note number for dah paddle (only used when mode is 'paddle', -1 = not assigned) */
   dahValue: number;
+  /** Indices into midiInputMappings that are allowed to relay through this output mapping */
+  relayInputIndices: number[];
+  /** When true, only relay sources (and encoder) drive this output — all other inputs are suppressed */
+  relaySuppressOtherInputs: boolean;
 }
 
 /** Configuration for a single serial input mapping */
@@ -184,6 +188,10 @@ export interface SerialOutputMapping {
   invert: boolean;
   /** Output forwarding mode: which signal source drives this mapping */
   forward: OutputForward;
+  /** Indices into serialInputMappings that are allowed to relay through this output mapping */
+  relayInputIndices: number[];
+  /** When true, only relay sources (and encoder) drive this output — all other inputs are suppressed */
+  relaySuppressOtherInputs: boolean;
 }
 
 /** Configuration for a single emoji replacement mapping */
@@ -276,6 +284,10 @@ export interface AppSettings {
   rtdbOutputOverrideName: boolean;
   /** When true, always send rtdbOutputColor — overriding any input-specific color */
   rtdbOutputOverrideColor: boolean;
+  /** When true, allow RTDB input characters to be relayed to RTDB output (disables echo suppression) */
+  rtdbAllowInputRelay: boolean;
+  /** When true, RTDB output only forwards chars from RTDB input relay — all other inputs are suppressed */
+  rtdbRelaySuppressOtherInputs: boolean;
 
   // --- 3. Audio Output (sidetone / headphone / speaker) ---
   sidetoneOutputDeviceId: string;
@@ -481,6 +493,8 @@ const DEFAULT_SETTINGS: AppSettings = {
       pin: 'dtr',
       invert: false,
       forward: 'tx',
+      relayInputIndices: [],
+      relaySuppressOtherInputs: false,
     },
   ],
 
@@ -531,6 +545,8 @@ const DEFAULT_SETTINGS: AppSettings = {
   rtdbOutputColor: '',
   rtdbOutputOverrideName: false,
   rtdbOutputOverrideColor: false,
+  rtdbAllowInputRelay: false,
+  rtdbRelaySuppressOtherInputs: false,
 
   sidetoneOutputDeviceId: 'default',
   sidetoneOutputChannel: 'left',
@@ -649,6 +665,8 @@ const DEFAULT_SETTINGS: AppSettings = {
       mode: 'straightKey',
       value: 80,
       dahValue: -1,
+      relayInputIndices: [],
+      relaySuppressOtherInputs: false,
     },
     {
       enabled: true,
@@ -658,6 +676,8 @@ const DEFAULT_SETTINGS: AppSettings = {
       mode: 'paddle',
       value: 82,
       dahValue: 84,
+      relayInputIndices: [],
+      relaySuppressOtherInputs: false,
     },
   ],
   midiOutputOverrideWpm: false,
@@ -1157,6 +1177,8 @@ export class SettingsService {
       pin,
       invert,
       forward,
+      relayInputIndices: [],
+      relaySuppressOtherInputs: false,
     }];
 
     const patch: any = { serialOutputMappings: mappings };

--- a/src/app/version.ts
+++ b/src/app/version.ts
@@ -1,2 +1,2 @@
 /** Single source of truth for the application version displayed in the UI. */
-export const APP_VERSION = '1.6.0';
+export const APP_VERSION = '1.6.1';


### PR DESCRIPTION
## Description

v1.6.1 adds per-mapping input relay for MIDI, Serial, and RTDB outputs — each output mapping can now select exactly which input mappings to forward, with an optional "Suppress Other Inputs" mode. It also fixes feedback loop prevention to work per-mapping instead of globally, cleans up relay index references when input mappings are deleted, and excludes relay traffic from loop-detection false positives. Mapping conflict detection in edit modals is downgraded from a blocking error to a non-blocking warning.

## Related Issue

Closes #14

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] My code follows the existing code style of the project
- [X] The app builds without errors (`ng build`)
- [X] I have tested my changes in Chrome or Edge
- [X] I have added/updated documentation as needed
