### PR TITLE
v1.6.2 minor ui bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.2] - 2026-03-15
+
+### Fixed
+
+- **Text Blur Scales with Font Size** — The fullscreen text-blur training
+  mode now uses a font-relative blur radius (`0.2em`) instead of a fixed
+  `5px`, so blurred text remains illegible even at the maximum 184 px font
+  size. A `brightness(1.5)` filter is also applied so the blurred text glows
+  rather than dissolving into the dark background.
+- **Input Card Name Colour** — Serial Input and MIDI Input card headers now
+  show the mapping name in the correct RX/TX foreground colour from the
+  fullscreen modal display settings (green for RX, amber for TX by default).
+  A per-mapping custom colour still takes priority when set.
+- **Fullscreen Auto-Scroll** — The fullscreen decoder and encoder views now
+  always scroll to the bottom when new characters arrive, fixing an issue
+  where auto-scroll would stop permanently after smooth-scroll animation lag
+  caused the distance-from-bottom threshold to be exceeded.
+- **MIDI Auto-Detect Channel** — The "Detect" button in the MIDI Input edit
+  modal now always updates the channel dropdown to the detected MIDI channel,
+  even when a specific channel was already selected. The note hint text below
+  each note field now includes the channel as a prefix (e.g. "Ch 3 / C4 (60)").
+
 ## [1.6.1] - 2026-03-15
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "morse-code-studio",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "morse-code-studio",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "CC0-1.0",
       "dependencies": {
         "@angular/animations": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morse-code-studio",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "A browser-based Morse code encoder, decoder and keyer built with Angular and the Web Audio API",
   "author": "5B4AON — Mike",
   "repository": {

--- a/src/app/components/fullscreen-modal/fs-decoder-view/fs-decoder-view.component.ts
+++ b/src/app/components/fullscreen-modal/fs-decoder-view/fs-decoder-view.component.ts
@@ -125,15 +125,11 @@ export class FsDecoderViewComponent implements OnInit, OnDestroy, OnChanges, Aft
       }
     }
 
-    // Auto-scroll to bottom when near the bottom or keyboard is open
+    // Auto-scroll to bottom on every content change
     if (this.needsScroll && this.conversationAreaRef) {
       const el = this.conversationAreaRef.nativeElement;
-      const nearBottom = this.viewportKeyboardOpen ||
-                         (el.scrollHeight - el.scrollTop - el.clientHeight < 120);
-      if (nearBottom) {
-        const behavior = this.viewportKeyboardOpen ? 'instant' as ScrollBehavior : 'smooth' as ScrollBehavior;
-        el.scrollTo({ top: el.scrollHeight, behavior });
-      }
+      const behavior = this.viewportKeyboardOpen ? 'instant' as ScrollBehavior : 'smooth' as ScrollBehavior;
+      el.scrollTo({ top: el.scrollHeight, behavior });
       this.needsScroll = false;
     }
   }

--- a/src/app/components/fullscreen-modal/fs-encoder-view/fs-encoder-view.component.ts
+++ b/src/app/components/fullscreen-modal/fs-encoder-view/fs-encoder-view.component.ts
@@ -136,15 +136,11 @@ export class FsEncoderViewComponent implements OnInit, OnDestroy, OnChanges, Aft
       }
     }
 
-    // Auto-scroll to bottom when near bottom or keyboard is open
+    // Auto-scroll to bottom on every content change
     if (this.needsScroll && this.conversationAreaRef) {
       const el = this.conversationAreaRef.nativeElement;
-      const nearBottom = this.viewportKeyboardOpen ||
-                         (el.scrollHeight - el.scrollTop - el.clientHeight < 120);
-      if (nearBottom) {
-        const behavior = this.viewportKeyboardOpen ? 'instant' as ScrollBehavior : 'smooth' as ScrollBehavior;
-        el.scrollTo({ top: el.scrollHeight, behavior });
-      }
+      const behavior = this.viewportKeyboardOpen ? 'instant' as ScrollBehavior : 'smooth' as ScrollBehavior;
+      el.scrollTo({ top: el.scrollHeight, behavior });
       this.needsScroll = false;
     }
 

--- a/src/app/components/fullscreen-modal/fullscreen-shared.css
+++ b/src/app/components/fullscreen-modal/fullscreen-shared.css
@@ -100,12 +100,14 @@
   transition: filter 250ms ease;
 }
 
-/* RX/TX line type markers (classes set on containing element) */
+/* RX/TX line type markers (classes set on containing element)
+   0.2em scales with font-size (≈5px at 24px, ≈37px at 184px);
+   brightness keeps blurred text visible against dark backgrounds */
 :host ::ng-deep .blur-rx .rx-line .line-text,
 :host ::ng-deep .blur-tx .tx-line .line-text,
 :host ::ng-deep .blur-both .rx-line .line-text,
 :host ::ng-deep .blur-both .tx-line .line-text {
-  filter: blur(5px);
+  filter: blur(0.2em) brightness(1.5);
 }
 
 /* Momentary reveal — overrides blur when held */
@@ -117,7 +119,7 @@
 /* Encoder pending chars blur */
 .fs-conversation.blur-tx .fs-encoder-inline,
 .fs-conversation.blur-both .fs-encoder-inline {
-  filter: blur(5px);
+  filter: blur(0.2em) brightness(1.5);
   transition: filter 250ms ease;
 }
 .fs-conversation.blur-revealing .fs-encoder-inline {

--- a/src/app/components/midi-input-edit-modal/midi-input-edit-modal.component.ts
+++ b/src/app/components/midi-input-edit-modal/midi-input-edit-modal.component.ts
@@ -143,10 +143,11 @@ export class MidiInputEditModalComponent implements OnInit, OnDestroy {
     return (octave + 1) * 12 + noteIndex;
   }
 
-  /** Display a MIDI note as human-readable name */
+  /** Display a MIDI note as human-readable name with channel prefix */
   noteDisplay(note: number): string {
     if (note < 0) return '(none)';
-    return `${midiNoteName(note)} (${note})`;
+    const ch = this.editChannel > 0 ? `Ch ${this.editChannel} / ` : '';
+    return `${ch}${midiNoteName(note)} (${note})`;
   }
 
   /** Handle note name dropdown change for value field */
@@ -213,11 +214,11 @@ export class MidiInputEditModalComponent implements OnInit, OnDestroy {
         this.editDahNote = this.getNoteIndex(result.note);
         this.editDahOctave = this.getOctave(result.note);
       }
-      // Auto-fill device and channel if not yet set
+      // Auto-fill device if not yet set; always update channel
       if (!this.editDeviceId && result.deviceId) {
         this.editDeviceId = result.deviceId;
       }
-      if (this.editChannel === 0 && result.channel > 0) {
+      if (result.channel > 0) {
         this.editChannel = result.channel;
       }
       this.capturing = null;

--- a/src/app/components/settings-modal/settings-inputs-tab/midi-input-card/midi-input-card.component.ts
+++ b/src/app/components/settings-modal/settings-inputs-tab/midi-input-card/midi-input-card.component.ts
@@ -193,10 +193,11 @@ export class MidiInputCardComponent {
     return m.channel === 0 ? 'Omni' : `Ch ${m.channel}`;
   }
 
-  /** Get the display color for a mapping's name label */
+  /** Get the display colour for a mapping's name label */
   nameColor(m: MidiInputMapping): string {
     if (m.color) return m.color;
-    return m.source === 'rx' ? '#8cf' : '#fc8';
+    const md = this.settings.modalDisplay();
+    return m.source === 'rx' ? md.rxForeground : md.txForeground;
   }
 
   /** Check whether a mapping's MIDI device is currently connected */

--- a/src/app/components/settings-modal/settings-inputs-tab/serial-input-card/serial-input-card.component.html
+++ b/src/app/components/settings-modal/settings-inputs-tab/serial-input-card/serial-input-card.component.html
@@ -50,7 +50,7 @@
                      (change)="onMappingEnabledChange($index, $event)">
             </label>
             @if (mapping.name) {
-              <span class="midi-mapping-name" (click)="startEdit($index)" [style.color]="mapping.color || null">{{ mapping.name }}</span>
+              <span class="midi-mapping-name" (click)="startEdit($index)" [style.color]="nameColor(mapping)">{{ mapping.name }}</span>
             }
             <span class="midi-mapping-mode" (click)="startEdit($index)">{{ mapping.mode === 'straightKey' ? 'Straight' : 'Paddle' }}</span>
             <span class="midi-mapping-value" (click)="startEdit($index)">

--- a/src/app/components/settings-modal/settings-inputs-tab/serial-input-card/serial-input-card.component.ts
+++ b/src/app/components/settings-modal/settings-inputs-tab/serial-input-card/serial-input-card.component.ts
@@ -187,6 +187,13 @@ export class SerialInputCardComponent {
     return PIN_LABELS[pin] || pin;
   }
 
+  /** Get the display colour for a mapping's name label */
+  nameColor(m: SerialInputMapping): string {
+    if (m.color) return m.color;
+    const md = this.settings.modalDisplay();
+    return m.source === 'rx' ? md.rxForeground : md.txForeground;
+  }
+
   /** Whether a specific mapping's port is connected */
   isMappingConnected(mapping: SerialInputMapping): boolean {
     return mapping.portIndex >= 0 && this.serialInput.isPortConnected(mapping.portIndex);

--- a/src/app/version.ts
+++ b/src/app/version.ts
@@ -1,2 +1,2 @@
 /** Single source of truth for the application version displayed in the UI. */
-export const APP_VERSION = '1.6.1';
+export const APP_VERSION = '1.6.2';


### PR DESCRIPTION
## Description

1. Text blur — Blur now scales with font size (uses 0.2em instead of fixed 5px) and adds brightness(1.5) so blurred text glows instead of disappearing
2. Input card name colour — Serial/MIDI input card names now show the correct RX/TX colour from modal display settings instead of default text colour or hardcoded values
3. Fullscreen auto-scroll — Always scrolls to bottom on new content, fixing the issue where smooth-scroll lag permanently broke auto-scroll
4. MIDI detect channel — Detect button always updates the channel dropdown (not just when set to Omni) and shows channel in the note hint text

## Related Issue

Closes #14

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] My code follows the existing code style of the project
- [X] The app builds without errors (`ng build`)
- [X] I have tested my changes in Chrome or Edge
- [X] I have added/updated documentation as needed
