### PR TITLE
v1.7.0 Farnsworth

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -80,8 +80,10 @@ src/app/
     │   │   ├── midi-output-card/
     │   │   ├── sidetone-card/
     │   │   └── vibration-card/
-    │   └── settings-other-tab/          — thin shell hosting 4 card components
+    │   └── settings-other-tab/          — thin shell hosting 6 card components
     │       ├── wake-lock-card/
+    │       ├── text-blur-card/
+    │       ├── farnsworth-card/
     │       ├── show-prosigns-card/
     │       ├── prosign-actions-card/
     │       └── emojis-card/
@@ -133,6 +135,7 @@ AppComponent
 - **`AppSettings` interface + `DEFAULT_SETTINGS`** (both in `settings.service.ts`): when adding a new setting, update the interface, add a default, and add the UI control in the appropriate settings card component.
 - **Prosign actions pipeline**: prosign keys are defined in `prosign-actions-card.component.ts` (`prosignKeys` array), their defaults in `DEFAULT_SETTINGS.prosignActions` (settings.service.ts), and they are consumed at runtime by `DisplayBufferService.handleProsignAction()`. All three must stay in sync.
 - **Emoji mappings pipeline**: emoji defaults in `DEFAULT_SETTINGS.emojiMappings`, UI in `emojis-card` + `EmojiEditModalComponent`, runtime processing in `DisplayBufferService`.
+- **Farnsworth / Wordsworth timing pipeline**: settings (`farnsworthEnabled`, etc.) in `AppSettings` + `DEFAULT_SETTINGS`, UI in `farnsworth-card`, timing math in `adjustGapTimings()` (morse-table.ts). Applied at runtime in `MorseEncoderService.sendCharacter()`, `startWordGapTimer()`, `playRxChar()` and `MidiOutputService.playCharElements()`. WinKeyer is excluded (hardware-timed).
 - **Keyboard input mappings pipeline**: `KeyboardInputMapping[]` in `AppSettings`, defaults in `DEFAULT_SETTINGS.keyboardInputMappings`, UI in `keyboard-keyer-card` + `KeyboardInputEditModalComponent`, runtime in `KeyerService` (per-mapping straight key state + independent paddle keyer per mapping).
 - **MIDI input mappings pipeline**: `MidiInputMapping[]` in `AppSettings`, defaults in `DEFAULT_SETTINGS.midiInputMappings`, UI in `midi-input-card` + `MidiInputEditModalComponent`, runtime in `MidiInputService` (per-mapping independent iambic keyer).
 - **MIDI output mappings pipeline**: `MidiOutputMapping[]` in `AppSettings`, defaults in `DEFAULT_SETTINGS.midiOutputMappings`, UI in `midi-output-card` + `MidiOutputEditModalComponent`, runtime in `MidiOutputService`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2026-03-16
+
+### Added
+
+- **Farnsworth Timing** — New setting under Settings → Other that stretches
+  the gaps between characters and words while keeping element durations
+  (dit/dah) at full speed. Named after Donald R. "Russ" Farnsworth (W6TTB),
+  this proven learning technique lowers the effective WPM without slowing
+  individual characters.
+- **Wordsworth Mode** — Optional variation that stretches only the gaps
+  between words, keeping inter-character spacing at the normal character
+  speed. Useful for operators who recognise characters instantly but need
+  extra time to process whole words.
+- **Two Input Modes** — Choose between *Effective WPM* (set a target overall
+  speed from 5 WPM up to the encoder WPM) or *Gap Multiplier* (multiply gap
+  durations by 1.00× to 10.00×).
+- **Applies To** selector — TX Only, RX Only, or Both. TX affects the
+  encoder and all keyed outputs (sidetone, serial, MIDI, vibration). RX
+  affects local playback of received characters (e.g. from Firebase RTDB).
+- **Affected Outputs** — Sidetone, optocoupler, serial DTR/RTS, MIDI note
+  output, and vibration. WinKeyer is excluded (hardware-timed).
+
+### Documentation
+
+- **Help §8.5 — Farnsworth / Wordsworth Timing** — New section explaining
+  both timing techniques, all controls, affected outputs, and a beginner
+  practice example. Subsequent sections renumbered (§8.5–8.7 → §8.6–8.8).
+
 ## [1.6.4] - 2026-03-16
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "morse-code-studio",
-  "version": "1.6.4",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "morse-code-studio",
-      "version": "1.6.4",
+      "version": "1.7.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@angular/animations": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morse-code-studio",
-  "version": "1.6.4",
+  "version": "1.7.0",
   "description": "A browser-based Morse code encoder, decoder and keyer built with Angular and the Web Audio API",
   "author": "5B4AON — Mike",
   "repository": {

--- a/src/app/components/help/help-ch-config.component.html
+++ b/src/app/components/help/help-ch-config.component.html
@@ -188,8 +188,60 @@
   even when the text is blurred, so you always know who is transmitting.
 </p>
 
-<!-- 8.5 Show Prosigns -->
-<h2 id="s8-5">8.5 &nbsp;Show Prosigns</h2>
+<!-- 8.5 Farnsworth / Wordsworth Timing -->
+<h2 id="s8-5">8.5 &nbsp;Farnsworth / Wordsworth Timing</h2>
+
+<p>
+  Found in <strong>Settings &rarr; Other</strong>. Farnsworth timing is a
+  learning technique that sends individual characters at full speed (your
+  normal Encoder WPM) but inserts exaggerated pauses between characters and
+  words, lowering the <em>effective</em> speed. Named after Donald&nbsp;R.
+  &ldquo;Russ&rdquo; Farnsworth (W6TTB), it helps you recognise characters at
+  real operating speed while giving you extra time to process what you hear.
+</p>
+
+<p>
+  <strong>Wordsworth mode</strong> is a variation that keeps whole characters
+  <em>and</em> inter-character spacing at full speed and only stretches the gaps
+  between words. This is useful for operators who have achieved instant character
+  recognition but need a little more time to recognise each word.
+</p>
+
+<h3>Controls</h3>
+<ul>
+  <li><strong>Applies to</strong> &mdash; choose TX Only, RX Only, or Both. TX
+      affects the encoder and keyed outputs (sidetone, serial, MIDI, vibration).
+      RX affects playback of received characters (e.g.&nbsp;from Firebase RTDB).</li>
+  <li><strong>Mode: Effective WPM</strong> &mdash; set a target overall WPM
+      (5 to your encoder WPM). The app calculates the correct gap durations so
+      the average word throughput matches your target.</li>
+  <li><strong>Mode: Gap Multiplier</strong> &mdash; directly multiply gap
+      durations by a factor between 1.00&times; and 10.00&times;. Element durations
+      (dit, dah) are never changed.</li>
+  <li><strong>Wordsworth mode</strong> checkbox &mdash; when ticked, only the
+      word gaps are stretched; inter-character gaps remain at normal speed.</li>
+</ul>
+
+<p>
+  Farnsworth timing applies to every output that synthesises element timing:
+  sidetone, vibration, MIDI, serial, Firebase RTDB, and audio key.
+  WinKeyer output is <strong>not affected</strong> because the WinKeyer
+  hardware generates its own timing.
+</p>
+
+<div class="example-box">
+  <div class="example-title">Example &mdash; Beginner Practice</div>
+  <p>
+    Set Encoder WPM to 20, enable Farnsworth Timing with Effective WPM
+    at&nbsp;10. Characters arrive at 20&thinsp;WPM speed &mdash; fast enough to
+    sound natural &mdash; but the gaps between them are long enough that the
+    overall throughput is only 10&thinsp;WPM, giving you time to write each
+    letter down.
+  </p>
+</div>
+
+<!-- 8.6 Show Prosigns -->
+<h2 id="s8-6">8.6 &nbsp;Show Prosigns</h2>
 
 <p>
   Found in <strong>Settings &rarr; Other</strong>. When enabled, punctuation
@@ -208,8 +260,8 @@
   regardless of this setting.
 </p>
 
-<!-- 8.6 Prosign Actions -->
-<h2 id="s8-6">8.6 &nbsp;Prosign Actions</h2>
+<!-- 8.7 Prosign Actions -->
+<h2 id="s8-7">8.7 &nbsp;Prosign Actions</h2>
 
 <p>
   Found in <strong>Settings &rarr; Other</strong>. When the master toggle is
@@ -285,8 +337,8 @@
   new lines start without a leading space.
 </p>
 
-<!-- 8.7 Emoji Replacements -->
-<h2 id="s8-7">8.7 &nbsp;Emoji Replacements</h2>
+<!-- 8.8 Emoji Replacements -->
+<h2 id="s8-8">8.8 &nbsp;Emoji Replacements</h2>
 
 <p>
   When enabled, emoji replacements substitute common morse abbreviations,

--- a/src/app/components/help/help.component.html
+++ b/src/app/components/help/help.component.html
@@ -86,9 +86,10 @@
         <a (click)="scrollTo('s8-2')">8.2 Device Profiles</a>
         <a (click)="scrollTo('s8-3')">8.3 Fullscreen Mode</a>
         <a (click)="scrollTo('s8-4')">8.4 Text Blurring</a>
-        <a (click)="scrollTo('s8-5')">8.5 Show Prosigns</a>
-        <a (click)="scrollTo('s8-6')">8.6 Prosign Actions</a>
-        <a (click)="scrollTo('s8-7')">8.7 Emoji Replacements</a>
+        <a (click)="scrollTo('s8-5')">8.5 Farnsworth / Wordsworth Timing</a>
+        <a (click)="scrollTo('s8-6')">8.6 Show Prosigns</a>
+        <a (click)="scrollTo('s8-7')">8.7 Prosign Actions</a>
+        <a (click)="scrollTo('s8-8')">8.8 Emoji Replacements</a>
       </div>
 
       <div class="toc-chapter">

--- a/src/app/components/settings-modal/settings-other-tab/farnsworth-card/farnsworth-card.component.html
+++ b/src/app/components/settings-modal/settings-other-tab/farnsworth-card/farnsworth-card.component.html
@@ -1,0 +1,90 @@
+<!-- Farnsworth / Wordsworth Timing -->
+<div class="settings-card" [class.disabled-card]="!settings.settings().farnsworthEnabled">
+  <div class="settings-card-header" (click)="expanded = !expanded">
+    <div class="settings-card-title">
+      <span class="settings-card-chevron">{{ expanded ? '&#9660;' : '&#9654;' }}</span>
+      <span class="settings-card-name">Farnsworth Timing</span>
+    </div>
+    <label class="toggle-switch" (click)="$event.stopPropagation()">
+      <input type="checkbox" [checked]="settings.settings().farnsworthEnabled"
+             (change)="onEnabledChange($event)">
+      <span class="toggle-slider"></span>
+    </label>
+  </div>
+  @if (expanded) {
+    <div class="settings-card-body">
+      <div class="cw-hint">
+        Farnsworth timing sends individual characters at full speed but
+        stretches the gaps between characters and words, lowering the
+        effective overall speed. This is a proven learning technique
+        named after Donald R. &ldquo;Russ&rdquo; Farnsworth (W6TTB)
+        that helps you recognise characters at real speed while giving
+        you extra thinking time.
+      </div>
+
+      <label>
+        Applies to:
+        <select [value]="settings.settings().farnsworthAppliesTo"
+                (change)="onAppliesToChange($event)">
+          <option value="tx">TX Only</option>
+          <option value="rx">RX Only</option>
+          <option value="both">Both RX and TX</option>
+        </select>
+      </label>
+
+      <label>
+        Mode:
+        <select [value]="settings.settings().farnsworthInputMode"
+                (change)="onInputModeChange($event)">
+          <option value="wpm">Effective WPM</option>
+          <option value="multiplier">Gap Multiplier</option>
+        </select>
+      </label>
+
+      @if (settings.settings().farnsworthInputMode === 'wpm') {
+        <label>
+          Effective WPM: {{ settings.settings().farnsworthEffectiveWpm }}
+          <input type="range" min="5" [max]="settings.settings().encoderWpm"
+                 step="1"
+                 [value]="settings.settings().farnsworthEffectiveWpm"
+                 (input)="onEffectiveWpmChange($event)">
+        </label>
+        <div class="cw-hint">
+          Characters are sent at {{ settings.settings().encoderWpm }}&thinsp;WPM
+          but the overall effective speed is
+          {{ settings.settings().farnsworthEffectiveWpm }}&thinsp;WPM.
+          The lower the effective WPM, the longer the gaps.
+        </div>
+      }
+
+      @if (settings.settings().farnsworthInputMode === 'multiplier') {
+        <label>
+          Gap multiplier: {{ settings.settings().farnsworthMultiplier.toFixed(2) }}&times;
+          <input type="range" min="1" max="10"
+                 step="0.01"
+                 [value]="settings.settings().farnsworthMultiplier"
+                 (input)="onMultiplierChange($event)">
+        </label>
+        <div class="cw-hint">
+          Gaps between characters and words are multiplied by
+          {{ settings.settings().farnsworthMultiplier.toFixed(2) }}.
+          Element durations (dit, dah) remain unchanged.
+        </div>
+      }
+
+      <label class="checkbox-label">
+        <input type="checkbox"
+               [checked]="settings.settings().farnsworthWordsworth"
+               (change)="onWordsworthChange($event)">
+        Wordsworth mode
+      </label>
+      <div class="cw-hint">
+        When enabled, only the gaps between <em>words</em> are stretched
+        &mdash; the gaps between characters remain at the normal character
+        speed. Wordsworth timing is useful for operators who have achieved
+        instant character recognition but need extra time to recognise and
+        process each word.
+      </div>
+    </div>
+  }
+</div>

--- a/src/app/components/settings-modal/settings-other-tab/farnsworth-card/farnsworth-card.component.ts
+++ b/src/app/components/settings-modal/settings-other-tab/farnsworth-card/farnsworth-card.component.ts
@@ -1,0 +1,71 @@
+/**
+ * Morse Code Studio
+ */
+
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { SettingsService } from '../../../../services/settings.service';
+
+/**
+ * Settings card — Farnsworth / Wordsworth Timing.
+ *
+ * Farnsworth timing sends individual characters at full speed but
+ * stretches the gaps between characters and words to lower the
+ * effective speed. Named after Donald R. "Russ" Farnsworth (W6TTB),
+ * the technique helps learners recognise characters at real speed
+ * while giving them extra thinking time.
+ *
+ * Wordsworth mode stretches only the inter-word gaps, keeping
+ * characters and inter-character spacing at full speed. This helps
+ * operators who have achieved instant character recognition but need
+ * extra time to process whole words.
+ */
+@Component({
+  selector: 'app-farnsworth-card',
+  standalone: true,
+  imports: [FormsModule],
+  templateUrl: './farnsworth-card.component.html',
+  styles: [':host { display: contents; }'],
+})
+export class FarnsworthCardComponent {
+  /** Whether this card's body is expanded */
+  expanded = false;
+
+  constructor(public settings: SettingsService) {}
+
+  /** Handle master toggle change */
+  onEnabledChange(event: Event): void {
+    const checked = (event.target as HTMLInputElement).checked;
+    this.settings.update({ farnsworthEnabled: checked });
+  }
+
+  /** Handle input mode change */
+  onInputModeChange(event: Event): void {
+    const value = (event.target as HTMLSelectElement).value as 'wpm' | 'multiplier';
+    this.settings.update({ farnsworthInputMode: value });
+  }
+
+  /** Handle effective WPM change */
+  onEffectiveWpmChange(event: Event): void {
+    const value = +(event.target as HTMLInputElement).value;
+    this.settings.update({ farnsworthEffectiveWpm: value });
+  }
+
+  /** Handle multiplier change */
+  onMultiplierChange(event: Event): void {
+    const value = +(event.target as HTMLInputElement).value;
+    this.settings.update({ farnsworthMultiplier: value });
+  }
+
+  /** Handle Wordsworth toggle change */
+  onWordsworthChange(event: Event): void {
+    const checked = (event.target as HTMLInputElement).checked;
+    this.settings.update({ farnsworthWordsworth: checked });
+  }
+
+  /** Handle applies-to selection change */
+  onAppliesToChange(event: Event): void {
+    const value = (event.target as HTMLSelectElement).value as 'tx' | 'rx' | 'both';
+    this.settings.update({ farnsworthAppliesTo: value });
+  }
+}

--- a/src/app/components/settings-modal/settings-other-tab/settings-other-tab.component.html
+++ b/src/app/components/settings-modal/settings-other-tab/settings-other-tab.component.html
@@ -1,7 +1,8 @@
-<!-- Other tab — Wake Lock, Text Blurring, Show Prosigns, Prosign Actions, Emojis -->
+<!-- Other tab — Wake Lock, Text Blurring, Farnsworth Timing, Show Prosigns, Prosign Actions, Emojis -->
 
 <app-wake-lock-card></app-wake-lock-card>
 <app-text-blur-card></app-text-blur-card>
+<app-farnsworth-card></app-farnsworth-card>
 <app-show-prosigns-card></app-show-prosigns-card>
 <app-prosign-actions-card></app-prosign-actions-card>
 <app-emojis-card></app-emojis-card>

--- a/src/app/components/settings-modal/settings-other-tab/settings-other-tab.component.ts
+++ b/src/app/components/settings-modal/settings-other-tab/settings-other-tab.component.ts
@@ -5,6 +5,7 @@
 import { Component } from '@angular/core';
 import { WakeLockCardComponent } from './wake-lock-card/wake-lock-card.component';
 import { TextBlurCardComponent } from './text-blur-card/text-blur-card.component';
+import { FarnsworthCardComponent } from './farnsworth-card/farnsworth-card.component';
 import { ShowProsignsCardComponent } from './show-prosigns-card/show-prosigns-card.component';
 import { ProsignActionsCardComponent } from './prosign-actions-card/prosign-actions-card.component';
 import { EmojisCardComponent } from './emojis-card/emojis-card.component';
@@ -12,7 +13,7 @@ import { EmojisCardComponent } from './emojis-card/emojis-card.component';
 /**
  * Settings — Other tab.
  *
- * Thin shell that renders the five miscellaneous settings cards as
+ * Thin shell that renders the six miscellaneous settings cards as
  * independent child components. Each card encapsulates its own
  * expand/collapse state, service injections, and event handlers.
  */
@@ -22,6 +23,7 @@ import { EmojisCardComponent } from './emojis-card/emojis-card.component';
   imports: [
     WakeLockCardComponent,
     TextBlurCardComponent,
+    FarnsworthCardComponent,
     ShowProsignsCardComponent,
     ProsignActionsCardComponent,
     EmojisCardComponent,

--- a/src/app/morse-table.ts
+++ b/src/app/morse-table.ts
@@ -140,3 +140,75 @@ export function timingsFromWpm(wpm: number) {
     interWord: ditMs * 7,   // space between words
   };
 }
+
+/** Farnsworth/Wordsworth settings subset needed by adjustGapTimings(). */
+export interface FarnsworthSettings {
+  farnsworthEnabled: boolean;
+  farnsworthInputMode: 'wpm' | 'multiplier';
+  farnsworthEffectiveWpm: number;
+  farnsworthMultiplier: number;
+  farnsworthWordsworth: boolean;
+  farnsworthAppliesTo: 'tx' | 'rx' | 'both';
+}
+
+/**
+ * Adjust inter-character and inter-word gap durations for Farnsworth or
+ * Wordsworth timing.
+ *
+ * Farnsworth timing keeps element durations (dit, dah, intra-char) at the
+ * character speed while stretching the gaps between characters and words
+ * proportionally. Named after Donald R. "Russ" Farnsworth (W6TTB).
+ *
+ * Wordsworth mode stretches only the inter-word gaps, leaving
+ * inter-character gaps at the normal character speed.
+ *
+ * @param timings  Base timing object from timingsFromWpm(charWpm)
+ * @param charWpm  Character speed (the WPM used to produce `timings`)
+ * @param source   Current output direction ('rx' or 'tx')
+ * @param fs       Farnsworth settings from AppSettings
+ * @returns A new timings object with adjusted interChar and interWord
+ */
+export function adjustGapTimings(
+  timings: ReturnType<typeof timingsFromWpm>,
+  charWpm: number,
+  source: 'rx' | 'tx',
+  fs: FarnsworthSettings,
+): ReturnType<typeof timingsFromWpm> {
+  if (!fs.farnsworthEnabled) return timings;
+  if (fs.farnsworthAppliesTo !== 'both' && fs.farnsworthAppliesTo !== source) return timings;
+
+  if (fs.farnsworthInputMode === 'multiplier') {
+    const m = Math.max(1, fs.farnsworthMultiplier);
+    if (m <= 1) return timings;
+    return {
+      ...timings,
+      interChar: fs.farnsworthWordsworth ? timings.interChar : timings.interChar * m,
+      interWord: timings.interWord * m,
+    };
+  }
+
+  // WPM mode
+  const effectiveWpm = Math.max(5, Math.min(fs.farnsworthEffectiveWpm, charWpm));
+  if (effectiveWpm >= charWpm) return timings;
+
+  const c = charWpm;
+  const s = effectiveWpm;
+
+  if (fs.farnsworthWordsworth) {
+    // Wordsworth: interChar unchanged, only interWord stretches.
+    // Total character content at speed c = (31 intra-element units + 12
+    // inter-char units for 4 gaps in PARIS) × ditMs. With standard
+    // PARIS: 43 element-units inside words = 51600/c ms. Remaining
+    // time in one minute at s WPM goes to the one inter-word gap per word.
+    const adjustedInterWord = Math.max(timings.interWord, 60000 / s - 51600 / c);
+    return { ...timings, interWord: adjustedInterWord };
+  }
+
+  // Farnsworth: both gaps stretch proportionally (3:7 ratio preserved).
+  // PARIS at charWpm takes 31 element-units of keying = 37200/c ms.
+  // The remaining time per word is distributed across the 19 gap-units.
+  const gapUnit = (60000 / s - 37200 / c) / 19;
+  const adjustedInterChar = Math.max(timings.interChar, 3 * gapUnit);
+  const adjustedInterWord = Math.max(timings.interWord, 7 * gapUnit);
+  return { ...timings, interChar: adjustedInterChar, interWord: adjustedInterWord };
+}

--- a/src/app/services/midi-output.service.ts
+++ b/src/app/services/midi-output.service.ts
@@ -4,7 +4,7 @@
 
 import { Injectable, OnDestroy, NgZone, signal } from '@angular/core';
 import { SettingsService } from './settings.service';
-import { MORSE_TABLE, timingsFromWpm } from '../morse-table';
+import { MORSE_TABLE, timingsFromWpm, adjustGapTimings } from '../morse-table';
 
 /**
  * MIDI note name lookup (scientific pitch notation).
@@ -371,7 +371,8 @@ export class MidiOutputService implements OnDestroy {
   private async playCharElements(char: string, source: 'rx' | 'tx', wpm?: number, paddleOnly = false, isFromRelay = false): Promise<void> {
     const s0 = this.settings.settings();
     const effectiveWpm = (wpm && !s0.midiOutputOverrideWpm) ? wpm : s0.encoderWpm;
-    const timings = timingsFromWpm(effectiveWpm);
+    const baseTimings = timingsFromWpm(effectiveWpm);
+    const timings = adjustGapTimings(baseTimings, effectiveWpm, source, s0);
     const s = this.settings.settings();
     const velocity = 127;
 

--- a/src/app/services/morse-encoder.service.ts
+++ b/src/app/services/morse-encoder.service.ts
@@ -5,7 +5,7 @@
 import { Injectable, signal } from '@angular/core';
 import { Subject } from 'rxjs';
 import { SettingsService } from './settings.service';
-import { MORSE_TABLE, timingsFromWpm } from '../morse-table';
+import { MORSE_TABLE, timingsFromWpm, adjustGapTimings } from '../morse-table';
 import { AudioOutputService } from './audio-output.service';
 import { SerialKeyOutputService } from './serial-key-output.service';
 import { VibrationOutputService } from './vibration-output.service';
@@ -234,8 +234,10 @@ export class MorseEncoderService {
   }
 
   private async sendCharacter(char: string, signal: AbortSignal): Promise<void> {
-    const timings = timingsFromWpm(this.settings.settings().encoderWpm);
-    const source = this.settings.settings().encoderSource;
+    const s = this.settings.settings();
+    const baseTimings = timingsFromWpm(s.encoderWpm);
+    const timings = adjustGapTimings(baseTimings, s.encoderWpm, s.encoderSource, s);
+    const source = s.encoderSource;
 
     if (char === ' ') {
       // Word space = 7 dit units total; 3 already elapsed as inter-char
@@ -295,7 +297,9 @@ export class MorseEncoderService {
    */
   private startWordGapTimer(): void {
     this.cancelWordGapTimer();
-    const timings = timingsFromWpm(this.settings.settings().encoderWpm);
+    const s = this.settings.settings();
+    const baseTimings = timingsFromWpm(s.encoderWpm);
+    const timings = adjustGapTimings(baseTimings, s.encoderWpm, s.encoderSource, s);
     const delay = timings.interWord - timings.interChar;
     this.wordGapTimer = setTimeout(() => {
       this.wordGapTimer = null;
@@ -354,7 +358,9 @@ export class MorseEncoderService {
   private async playRxChar(char: string, source: 'rx' | 'tx', wpm?: number): Promise<void> {
     // Skip output if loop is suppressed
     if (this.loopDetection.isSuppressed) return;
-    const timings = timingsFromWpm(wpm ?? this.settings.settings().encoderWpm);
+    const charWpm = wpm ?? this.settings.settings().encoderWpm;
+    const baseTimings = timingsFromWpm(charWpm);
+    const timings = adjustGapTimings(baseTimings, charWpm, source, this.settings.settings());
 
     if (char === ' ') {
       await this.sleepMs(timings.interWord - timings.interChar);

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -422,6 +422,20 @@ export interface AppSettings {
   /** Per-prosign action mappings */
   prosignActions: Record<string, ProsignActionEntry>;
 
+  // --- Farnsworth / Wordsworth Timing ---
+  /** Master toggle for Farnsworth gap stretching */
+  farnsworthEnabled: boolean;
+  /** How the user specifies gap stretching: effective WPM or direct multiplier */
+  farnsworthInputMode: 'wpm' | 'multiplier';
+  /** Target effective WPM when inputMode is 'wpm' (range: 5 to encoderWpm) */
+  farnsworthEffectiveWpm: number;
+  /** Direct gap multiplier when inputMode is 'multiplier' (range: 1.00 to 10.00) */
+  farnsworthMultiplier: number;
+  /** Wordsworth mode: stretch only word gaps (not inter-character gaps) */
+  farnsworthWordsworth: boolean;
+  /** Which direction Farnsworth timing applies to: tx, rx, or both */
+  farnsworthAppliesTo: 'tx' | 'rx' | 'both';
+
   // --- Emoji Replacements ---
   /** Master toggle for emoji display in fullscreen modals */
   emojisEnabled: boolean;
@@ -703,6 +717,13 @@ const DEFAULT_SETTINGS: AppSettings = {
 
   textBlurEnabled: false,
   textBlurAppliesTo: 'rx',
+
+  farnsworthEnabled: false,
+  farnsworthInputMode: 'wpm',
+  farnsworthEffectiveWpm: 10,
+  farnsworthMultiplier: 2,
+  farnsworthWordsworth: false,
+  farnsworthAppliesTo: 'tx',
 
   wakeLockEnabled: false,
 

--- a/src/app/version.ts
+++ b/src/app/version.ts
@@ -1,2 +1,2 @@
 /** Single source of truth for the application version displayed in the UI. */
-export const APP_VERSION = '1.6.4';
+export const APP_VERSION = '1.7.0';


### PR DESCRIPTION
## Description

v1.7.0 adds Farnsworth/Wordsworth timing — a learning aid that stretches gaps between characters (Farnsworth) or only between words (Wordsworth) while keeping dit/dah element speeds unchanged. Users choose between an effective WPM target or a direct gap multiplier, and can apply the timing to TX, RX, or both. Affects sidetone, opto, serial, MIDI, and vibration outputs; WinKeyer is excluded. A new help section (§8.5) documents the feature.

## Related Issue

Closes #18

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] My code follows the existing code style of the project
- [X] The app builds without errors (`ng build`)
- [X] I have tested my changes in Chrome or Edge
- [X] I have added/updated documentation as needed
